### PR TITLE
Tests and companion

### DIFF
--- a/android/src/main/kotlin/biz/cunning/cunning_document_scanner/CunningDocumentScannerPlugin.kt
+++ b/android/src/main/kotlin/biz/cunning/cunning_document_scanner/CunningDocumentScannerPlugin.kt
@@ -21,7 +21,6 @@ class CunningDocumentScannerPlugin : FlutterPlugin, MethodCallHandler, ActivityA
     private var binding: ActivityPluginBinding? = null
     private var pendingResult: Result? = null
     private lateinit var activity: Activity
-    private val START_DOCUMENT_ACTIVITY: Int = 0x362738
 
     /// The MethodChannel that will the communication between Flutter and native Android
     ///
@@ -156,5 +155,9 @@ class CunningDocumentScannerPlugin : FlutterPlugin, MethodCallHandler, ActivityA
 
     private fun removeActivityResultListener() {
         this.delegate?.let { this.binding?.removeActivityResultListener(it) }
+    }
+
+    companion object {
+        private const val START_DOCUMENT_ACTIVITY: Int = 0x362738
     }
 }

--- a/example/test/widget_test.dart
+++ b/example/test/widget_test.dart
@@ -11,7 +11,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:cunning_document_scanner_example/main.dart';
 
 void main() {
-  testWidgets('Verify Platform version', (WidgetTester tester) async {
+  testWidgets('View is created', (WidgetTester tester) async {
     // Build our app and trigger a frame.
     await tester.pumpWidget(const MyApp());
 
@@ -19,7 +19,7 @@ void main() {
     expect(
       find.byWidgetPredicate(
         (Widget widget) =>
-            widget is Text && widget.data!.startsWith('Running on:'),
+            widget is Text && widget.data!.startsWith('Add Pictures'),
       ),
       findsOneWidget,
     );


### PR DESCRIPTION
- On Android is recommended to have companion object instead var to avoid that if multiple instances of this class are created Kotlin does not create multiple instances it is more optimal to have it in a companion.

- Tests now is passing again.