### PR TITLE
Feature/android scanner mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ There are some features in Android that allow you to adjust the scanner that wil
    final imagesPath = await CunningDocumentScanner.getPictures(
       noOfPages: 1, // Limit the number of pages to 1
       isGalleryImportAllowed, // Allow the user to also pick an image from his gallery
-      androidScannerMode: AndroidScannerMode.base, // Use ML Kit base mode on Android
+      androidScannerMode: AndroidScannerMode.base, // Use ML Kit base mode on Android (Optional)
    );
 ```
 

--- a/README.md
+++ b/README.md
@@ -97,12 +97,15 @@ There are some features in Android that allow you to adjust the scanner that wil
    final imagesPath = await CunningDocumentScanner.getPictures(
       noOfPages: 1, // Limit the number of pages to 1
       isGalleryImportAllowed, // Allow the user to also pick an image from his gallery
+      androidScannerMode: AndroidScannerMode.base, // Use ML Kit base mode on Android
    );
 ```
 
 ### iOS Specific
 
 On iOS it is possible to configure which image format should be used to save of the document scans. Available options are PNG (default) or JPEG. In certain situations the JPEG format could drastically reduce the file size of the final scan. If you choose to use JPEG you can also specify a compression quality, where 0.0 is highest compression (lowest quality) and 1.0 (default) is the lowest compression (highest quality). Example usage is:
+
+Note: VisionKit does not expose a scanner mode or filter toggle on iOS. To disable filters or use only crop/rotation, a custom capture and cropping UI would be required.
 
 ```dart
    // Returns images in JPEG format with a compression quality of 50%. 

--- a/android/src/main/kotlin/biz/cunning/cunning_document_scanner/CunningDocumentScannerPlugin.kt
+++ b/android/src/main/kotlin/biz/cunning/cunning_document_scanner/CunningDocumentScannerPlugin.kt
@@ -10,6 +10,8 @@ import biz.cunning.cunning_document_scanner.fallback.constants.DocumentScannerEx
 import com.google.mlkit.common.MlKitException
 import com.google.mlkit.vision.documentscanner.GmsDocumentScannerOptions
 import com.google.mlkit.vision.documentscanner.GmsDocumentScannerOptions.RESULT_FORMAT_JPEG
+import com.google.mlkit.vision.documentscanner.GmsDocumentScannerOptions.SCANNER_MODE_BASE
+import com.google.mlkit.vision.documentscanner.GmsDocumentScannerOptions.SCANNER_MODE_BASE_WITH_FILTER
 import com.google.mlkit.vision.documentscanner.GmsDocumentScannerOptions.SCANNER_MODE_FULL
 import com.google.mlkit.vision.documentscanner.GmsDocumentScanning
 import com.google.mlkit.vision.documentscanner.GmsDocumentScanningResult
@@ -48,8 +50,9 @@ class CunningDocumentScannerPlugin : FlutterPlugin, MethodCallHandler, ActivityA
         if (call.method == "getPictures") {
             val noOfPages = call.argument<Int>("noOfPages") ?: 50;
             val isGalleryImportAllowed = call.argument<Boolean>("isGalleryImportAllowed") ?: false;
+            val scannerMode = resolveScannerMode(call.argument<String>("androidScannerMode"))
             this.pendingResult = result
-            startScan(noOfPages, isGalleryImportAllowed)
+            startScan(noOfPages, isGalleryImportAllowed, scannerMode)
         } else {
             result.notImplemented()
         }
@@ -169,12 +172,21 @@ class CunningDocumentScannerPlugin : FlutterPlugin, MethodCallHandler, ActivityA
     /**
      * add document scanner result handler and launch the document scanner
      */
-    private fun startScan(noOfPages: Int, isGalleryImportAllowed: Boolean) {
+    private fun resolveScannerMode(mode: String?): Int {
+        return when (mode) {
+            "base" -> SCANNER_MODE_BASE
+            "base_with_filter" -> SCANNER_MODE_BASE_WITH_FILTER
+            "full", null -> SCANNER_MODE_FULL
+            else -> SCANNER_MODE_FULL
+        }
+    }
+
+    private fun startScan(noOfPages: Int, isGalleryImportAllowed: Boolean, scannerMode: Int) {
         val options = GmsDocumentScannerOptions.Builder()
             .setGalleryImportAllowed(isGalleryImportAllowed)
             .setPageLimit(noOfPages)
             .setResultFormats(RESULT_FORMAT_JPEG)
-            .setScannerMode(SCANNER_MODE_FULL)
+            .setScannerMode(scannerMode)
             .build()
         val scanner = GmsDocumentScanning.getClient(options)
         scanner.getStartScanIntent(activity).addOnSuccessListener {

--- a/lib/cunning_document_scanner.dart
+++ b/lib/cunning_document_scanner.dart
@@ -1,6 +1,7 @@
 // Cunning Document Scanner - A simple document scanning library for Flutter.
 
 export 'src/cunning_document_scanner.dart';
+export 'src/android_scanner_mode.dart';
 export 'src/exceptions.dart';
 export 'src/ios_image_format.dart';
 export 'src/ios_scanner_options.dart';

--- a/lib/src/android_scanner_mode.dart
+++ b/lib/src/android_scanner_mode.dart
@@ -1,0 +1,24 @@
+/// Android-only scanner modes for ML Kit document scanning.
+enum AndroidScannerMode {
+  /// Full feature set including ML-based enhancements.
+  full,
+
+  /// Basic scan pipeline without filters.
+  base,
+
+  /// Basic scan pipeline with filters.
+  baseWithFilter,
+}
+
+extension AndroidScannerModeValue on AndroidScannerMode {
+  String get methodChannelValue {
+    switch (this) {
+      case AndroidScannerMode.full:
+        return 'full';
+      case AndroidScannerMode.base:
+        return 'base';
+      case AndroidScannerMode.baseWithFilter:
+        return 'base_with_filter';
+    }
+  }
+}

--- a/lib/src/cunning_document_scanner.dart
+++ b/lib/src/cunning_document_scanner.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/services.dart';
 import 'package:permission_handler/permission_handler.dart';
 
+import 'android_scanner_mode.dart';
 import 'exceptions.dart';
 import 'ios_scanner_options.dart';
 
@@ -18,12 +19,14 @@ class CunningDocumentScanner {
   ///
   /// [noOfPages] is the maximum number of pages that can be scanned.
   /// [isGalleryImportAllowed] is a flag that allows the user to import images from the gallery.
+  /// [androidScannerMode] controls the ML Kit scanner mode on Android only.
   /// [iosScannerOptions] is a set of options for the iOS scanner.
   ///
   /// Returns a list of paths to the scanned images, or null if the user cancels the operation.
   static Future<List<String>?> getPictures({
     int noOfPages = 100,
     bool isGalleryImportAllowed = false,
+    AndroidScannerMode? androidScannerMode = AndroidScannerMode.full,
     IosScannerOptions? iosScannerOptions,
   }) async {
     Map<Permission, PermissionStatus> statuses = await [
@@ -38,6 +41,7 @@ class CunningDocumentScanner {
     final List<dynamic>? pictures = await _channel.invokeMethod('getPictures', {
       'noOfPages': noOfPages,
       'isGalleryImportAllowed': isGalleryImportAllowed,
+      'androidScannerMode': androidScannerMode.methodChannelValue,
       if (iosScannerOptions != null)
         'iosScannerOptions': {
           'imageFormat': iosScannerOptions.imageFormat.name,

--- a/lib/src/cunning_document_scanner.dart
+++ b/lib/src/cunning_document_scanner.dart
@@ -41,7 +41,7 @@ class CunningDocumentScanner {
     final List<dynamic>? pictures = await _channel.invokeMethod('getPictures', {
       'noOfPages': noOfPages,
       'isGalleryImportAllowed': isGalleryImportAllowed,
-      'androidScannerMode': androidScannerMode.methodChannelValue,
+      'androidScannerMode': androidScannerMode?.methodChannelValue,
       if (iosScannerOptions != null)
         'iosScannerOptions': {
           'imageFormat': iosScannerOptions.imageFormat.name,


### PR DESCRIPTION
This pull request adds support for configuring the ML Kit scanner mode on Android, allowing developers to choose between different scanning pipelines (full, base, or base with filter). It introduces a new `AndroidScannerMode` enum in the Dart API, updates the Android implementation to respect this setting, and documents the new feature in the README. No changes are made to iOS scanning behavior.

**Android scanner mode support:**
* Added a new `AndroidScannerMode` enum in `lib/src/android_scanner_mode.dart` to represent available ML Kit scanner modes and expose them in the Dart API.
* Updated `CunningDocumentScanner.getPictures` to accept an optional `androidScannerMode` parameter, defaulting to `full`, and pass it to the platform channel. [[1]](diffhunk://#diff-2c124544a65ea74c83cd5678fea98722c7b7ef3a05270e0964cfc838eb21f05eR22-R29) [[2]](diffhunk://#diff-2c124544a65ea74c83cd5678fea98722c7b7ef3a05270e0964cfc838eb21f05eR44)
* Exported `android_scanner_mode.dart` from the main library file for public use.

**Android implementation changes:**
* Modified the plugin Kotlin code to accept the scanner mode from the method call, resolve the correct ML Kit constant, and configure the scanner accordingly. [[1]](diffhunk://#diff-c658e4e9b9b1c3695d368fb97c4131dc4ef190723fac1e4b096f0381cb2dba11R53-R55) [[2]](diffhunk://#diff-c658e4e9b9b1c3695d368fb97c4131dc4ef190723fac1e4b096f0381cb2dba11L172-R189)
* Imported the necessary ML Kit scanner mode constants.

**Documentation:**
* Updated the README to document the new `androidScannerMode` parameter and clarify that scanner mode selection is not available on iOS.