### PR TITLE
Refactor: remove redundant camera and storage permissions from Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 2.5.0
+### Android
+* Removed redundant camera and storage permissions from `AndroidManifest.xml`.
+* Android no longer prompts the user for camera or storage permissions at runtime since ML Kit and the fallback camera intent handle them without requiring permission in the host app.
+
+### iOS
+* Camera permission request remains active and required for iOS VisionKit.
+
 ## 2.4.0
 ### Android
 * Migrated to "Built-in Kotlin" support, removing manual Kotlin Gradle Plugin (KGP) application for future Flutter compatibility.

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,10 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="biz.cunning.cunning_document_scanner">
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.CAMERA" />
-    <uses-feature android:name="android.hardware.camera"
-                  android:required="true" />
     <application android:theme="@style/Theme.AppCompat.NoActionBar">
         <activity
             android:name=".fallback.DocumentScannerActivity"

--- a/example/android/app/build.gradle.kts
+++ b/example/android/app/build.gradle.kts
@@ -23,6 +23,7 @@ val flutterVersionName =
 android {
     namespace = "biz.cunning.cunning_document_scanner_example"
     compileSdk = 36
+    ndkVersion = "28.2.13676358"
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17

--- a/lib/src/cunning_document_scanner.dart
+++ b/lib/src/cunning_document_scanner.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:permission_handler/permission_handler.dart';
 
@@ -29,13 +30,15 @@ class CunningDocumentScanner {
     AndroidScannerMode? androidScannerMode = AndroidScannerMode.full,
     IosScannerOptions? iosScannerOptions,
   }) async {
-    Map<Permission, PermissionStatus> statuses = await [
-      Permission.camera,
-    ].request();
-    if (statuses.containsValue(PermissionStatus.denied) ||
-        statuses.containsValue(PermissionStatus.permanentlyDenied)) {
-      throw const CunningDocumentScannerException.permissionDenied(
-          'Camera permission not granted');
+    if (defaultTargetPlatform == TargetPlatform.iOS) {
+      final Map<Permission, PermissionStatus> statuses = await [
+        Permission.camera,
+      ].request();
+      if (statuses.containsValue(PermissionStatus.denied) ||
+          statuses.containsValue(PermissionStatus.permanentlyDenied)) {
+        throw const CunningDocumentScannerException.permissionDenied(
+            'Camera permission not granted');
+      }
     }
 
     final List<dynamic>? pictures = await _channel.invokeMethod('getPictures', {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cunning_document_scanner
 description: A document scanner plugin for flutter. Scan and crop automatically on iOS and Android.
-version: 2.4.0
+version: 2.5.0
 homepage: https://cunning.biz
 repository: https://github.com/jachzen/cunning_document_scanner
 

--- a/test/cunning_document_scanner_test.dart
+++ b/test/cunning_document_scanner_test.dart
@@ -1,4 +1,5 @@
 import 'package:cunning_document_scanner/cunning_document_scanner.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:permission_handler_platform_interface/permission_handler_platform_interface.dart';
@@ -8,8 +9,13 @@ import 'mocks/mock_permission_handler_platform.dart';
 void main() {
   group('CunningDocumentScanner permission denied', () {
     setUp(() {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
       PermissionHandlerPlatform.instance = MockPermissionHandlerPlatform(
           permissionStatus: PermissionStatus.denied);
+    });
+
+    tearDown(() {
+      debugDefaultTargetPlatformOverride = null;
     });
 
     test('getPictures with denied permission', () async {
@@ -25,8 +31,13 @@ void main() {
 
   group('CunningDocumentScanner permission permanently denied', () {
     setUp(() {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
       PermissionHandlerPlatform.instance = MockPermissionHandlerPlatform(
           permissionStatus: PermissionStatus.permanentlyDenied);
+    });
+
+    tearDown(() {
+      debugDefaultTargetPlatformOverride = null;
     });
 
     test('getPictures with permanently denied permission', () async {


### PR DESCRIPTION
This PR removes the unnecessary Camera and Storage permission requirements for Android, keeping them active only on iOS where they are actually needed by VisionKit.

### Changes
* Removed `android.permission.CAMERA`, `READ_EXTERNAL_STORAGE`, and `WRITE_EXTERNAL_STORAGE` permissions from the plugin's `AndroidManifest.xml`.
* Updated the Dart `getPictures` method to request `Permission.camera` only on iOS.
* Scoped `debugDefaultTargetPlatformOverride = TargetPlatform.iOS` to target-specific tests in `cunning_document_scanner_test.dart` to verify permission denial flows without causing debug variables leaks in widget tests.
* Bumped version to `2.5.0` in `pubspec.yaml` and updated the `CHANGELOG.md`.