### PR TITLE
Feature: add native gallery import support on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### iOS
 * Camera permission request remains active and required for iOS VisionKit.
 * Integrated native PDF compilation using `PDFKit` (converting VisionKit scan pages into a single PDF document).
+* Added native support for `isGalleryImportAllowed` on iOS. Users can now choose to scan using the camera (VisionKit) or import existing documents from their photo library (`PHPickerViewController` on iOS 14+ supporting multi-selection, and `UIImagePickerController` on iOS 13). Imported images undergo the same native PDF/image conversion pipeline.
 
 ## 2.4.0
 ### Android

--- a/README.md
+++ b/README.md
@@ -59,6 +59,21 @@ Add the [NSCameraUsageDescription](https://developer.apple.com/documentation/bun
 > [!NOTE]
 > Since this plugin has migrated to Swift Package Manager (SPM), and the `permission_handler` dependency (version 12.0.2+) also supports SPM, permissions are now resolved automatically. The dependency scans your app's `Info.plist` and compiles only the code for the permission keys you have declared (e.g., `NSCameraUsageDescription`). You do not need to manually configure preprocessor macros in your `Podfile`.
 
+#### Localization Configuration
+To ensure native iOS UI components (like the document camera, photo library picker, and our source selection menu) are displayed in the user's preferred language (e.g., Spanish), you can enable mixed localizations in your app's `ios/Runner/Info.plist`:
+
+```xml
+<key>CFBundleAllowMixedLocalizations</key>
+<true/>
+```
+
+Alternatively, you can add the supported languages to the **Localizations** list in Xcode:
+1. Open `ios/Runner.xcworkspace` in Xcode.
+2. Select the `Runner` project in the left project navigator.
+3. In the **Info** tab, under the **Localizations** section, click the `+` button and add the languages your app supports.
+
+If one of these configurations is applied, iOS will automatically load the plugin's built-in translations (supporting 29 major languages) and translate the system document camera UI to the device's system language. Otherwise, iOS will default all system and plugin UI strings to English.
+
 ## How to use ?
 
 The easiest way to get a list of images is:

--- a/README.md
+++ b/README.md
@@ -78,6 +78,16 @@ You can also scan directly to a single PDF document. If `asPdf` is set to `true`
    // pdfPath will be something like: ['/path/to/document.pdf']
 ```
 
+### Gallery Import (Cross-Platform)
+
+Allow the user to import images from their photo library/gallery on both Android and iOS:
+
+```dart
+   final imagesPath = await CunningDocumentScanner.getPictures(
+      isGalleryImportAllowed: true, // Show selection sheet/picker to import from photo library
+   );
+```
+
 ### Android Specific
 
 There are some features in Android that allow you to adjust the scanner that will be ignored in iOS:
@@ -85,7 +95,6 @@ There are some features in Android that allow you to adjust the scanner that wil
 ```dart
    final imagesPath = await CunningDocumentScanner.getPictures(
       noOfPages: 1, // Limit the number of pages to 1
-      isGalleryImportAllowed: true, // Allow the user to also pick an image from his gallery
       androidScannerMode: AndroidScannerMode.base, // Use ML Kit base mode on Android (Optional)
    );
 ```

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -162,6 +162,7 @@
 			knownRegions = (
 				en,
 				Base,
+				es,
 			);
 			mainGroup = 97C146E51CF9000F007C117D;
 			packageReferences = (

--- a/example/ios/Runner/Info.plist
+++ b/example/ios/Runner/Info.plist
@@ -6,6 +6,8 @@
 	<true/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleAllowMixedLocalizations</key>
+	<true/>
 	<key>CFBundleDisplayName</key>
 	<string>Cunning Document Scanner</string>
 	<key>CFBundleExecutable</key>

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -20,6 +20,7 @@ class _MyAppState extends State<MyApp> {
   List<String> _pictures = [];
   bool _asPdf = false;
   bool _isPdfResult = false;
+  bool _isGalleryImportAllowed = false;
 
   @override
   void initState() {
@@ -47,6 +48,16 @@ class _MyAppState extends State<MyApp> {
               onChanged: (value) {
                 setState(() {
                   _asPdf = value;
+                });
+              },
+            ),
+            SwitchListTile(
+              title: const Text("Allow Gallery Import"),
+              subtitle: const Text("Import documents from photo library"),
+              value: _isGalleryImportAllowed,
+              onChanged: (value) {
+                setState(() {
+                  _isGalleryImportAllowed = value;
                 });
               },
             ),
@@ -108,7 +119,7 @@ class _MyAppState extends State<MyApp> {
     List<String> pictures;
     try {
       pictures = await CunningDocumentScanner.getPictures(
-              isGalleryImportAllowed: true,
+              isGalleryImportAllowed: _isGalleryImportAllowed,
               asPdf: _asPdf,
               iosScannerOptions: IosScannerOptions(
                 imageFormat: IosImageFormat.jpg,

--- a/ios/cunning_document_scanner.podspec
+++ b/ios/cunning_document_scanner.podspec
@@ -14,6 +14,7 @@ A new flutter plugin project.
   s.author           = { 'Cunning GmbH' => 'marcel@cunning.biz' }
   s.source           = { :path => '.' }
   s.source_files = 'cunning_document_scanner/Sources/cunning_document_scanner/**/*.swift'
+  s.resources = 'cunning_document_scanner/Sources/cunning_document_scanner/Resources/**/*'
   s.dependency 'Flutter'
   s.platform = :ios, '13.0'
 

--- a/ios/cunning_document_scanner/Package.swift
+++ b/ios/cunning_document_scanner/Package.swift
@@ -3,6 +3,7 @@ import PackageDescription
 
 let package = Package(
     name: "cunning_document_scanner",
+    defaultLocalization: "en",
     platforms: [
         .iOS("13.0")
     ],
@@ -17,6 +18,9 @@ let package = Package(
             name: "cunning_document_scanner",
             dependencies: [
                 .product(name: "FlutterFramework", package: "FlutterFramework")
+            ],
+            resources: [
+                .process("Resources")
             ]
         )
     ]

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/CunningDocumentScannerPlugin.swift
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/CunningDocumentScannerPlugin.swift
@@ -3,9 +3,11 @@ import UIKit
 import Vision
 import VisionKit
 import PDFKit
+import Photos
+import PhotosUI
 
 @available(iOS 13.0, *)
-public class CunningDocumentScannerPlugin: NSObject, FlutterPlugin, VNDocumentCameraViewControllerDelegate {
+public class CunningDocumentScannerPlugin: NSObject, FlutterPlugin, VNDocumentCameraViewControllerDelegate, UIImagePickerControllerDelegate, UINavigationControllerDelegate {
     var resultChannel: FlutterResult?
     var presentingController: VNDocumentCameraViewController?
     var scannerOptions = CunningScannerOptions()
@@ -26,12 +28,59 @@ public class CunningDocumentScannerPlugin: NSObject, FlutterPlugin, VNDocumentCa
         let presentedVC = UIApplication.shared.keyWindow?.rootViewController
         resultChannel = result
 
+        if scannerOptions.isGalleryImportAllowed {
+            let alertController = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+            
+            let cameraAction = UIAlertAction(title: "Camera", style: .default) { _ in
+                self.openCamera(from: presentedVC)
+            }
+            let galleryAction = UIAlertAction(title: "Gallery", style: .default) { _ in
+                self.openGallery(from: presentedVC)
+            }
+            let cancelAction = UIAlertAction(title: "Cancel", style: .cancel) { _ in
+                self.resultChannel?(nil)
+            }
+            
+            alertController.addAction(cameraAction)
+            alertController.addAction(galleryAction)
+            alertController.addAction(cancelAction)
+            
+            if let popoverController = alertController.popoverPresentationController {
+                popoverController.sourceView = presentedVC?.view
+                popoverController.sourceRect = CGRect(x: presentedVC?.view.bounds.midX ?? 0, y: presentedVC?.view.bounds.midY ?? 0, width: 0, height: 0)
+                popoverController.permittedArrowDirections = []
+            }
+            
+            presentedVC?.present(alertController, animated: true)
+        } else {
+            self.openCamera(from: presentedVC)
+        }
+    }
+
+    func openCamera(from presentedVC: UIViewController?) {
         if VNDocumentCameraViewController.isSupported {
             presentingController = VNDocumentCameraViewController()
             presentingController?.delegate = self
             presentedVC?.present(presentingController!, animated: true)
         } else {
-            result(FlutterError(code: "UNAVAILABLE", message: "Document camera is not available on this device", details: nil))
+            resultChannel?(FlutterError(code: "UNAVAILABLE", message: "Document camera is not available on this device", details: nil))
+        }
+    }
+
+    func openGallery(from presentedVC: UIViewController?) {
+        if #available(iOS 14.0, *) {
+            var configuration = PHPickerConfiguration()
+            configuration.filter = .images
+            configuration.selectionLimit = 0
+            
+            let picker = PHPickerViewController(configuration: configuration)
+            picker.delegate = self
+            presentedVC?.present(picker, animated: true)
+        } else {
+            let picker = UIImagePickerController()
+            picker.sourceType = .photoLibrary
+            picker.delegate = self
+            presentedVC?.present(picker, animated: true)
         }
     }
 
@@ -40,7 +89,7 @@ public class CunningDocumentScannerPlugin: NSObject, FlutterPlugin, VNDocumentCa
         return paths[0]
     }
 
-    public func documentCameraViewController(_ controller: VNDocumentCameraViewController, didFinishWith scan: VNDocumentCameraScan) {
+    func processSelectedImages(_ images: [UIImage]) {
         let tempDirPath = getDocumentsDirectory()
         let currentDateTime = Date()
         let df = DateFormatter()
@@ -49,8 +98,7 @@ public class CunningDocumentScannerPlugin: NSObject, FlutterPlugin, VNDocumentCa
 
         if scannerOptions.asPdf {
             let pdfDocument = PDFDocument()
-            for i in 0 ..< scan.pageCount {
-                let pageImage = scan.imageOfPage(at: i)
+            for (i, pageImage) in images.enumerated() {
                 if let pdfPage = PDFPage(image: pageImage) {
                     pdfDocument.insert(pdfPage, at: i)
                 }
@@ -63,8 +111,7 @@ public class CunningDocumentScannerPlugin: NSObject, FlutterPlugin, VNDocumentCa
             }
         } else {
             var filenames: [String] = []
-            for i in 0 ..< scan.pageCount {
-                let page = scan.imageOfPage(at: i)
+            for (i, page) in images.enumerated() {
                 let url = tempDirPath.appendingPathComponent(formattedDate + "-\(i).\(scannerOptions.imageFormat.rawValue)")
 
                 switch scannerOptions.imageFormat {
@@ -78,6 +125,16 @@ public class CunningDocumentScannerPlugin: NSObject, FlutterPlugin, VNDocumentCa
             }
             resultChannel?(filenames)
         }
+    }
+
+    // MARK: - VNDocumentCameraViewControllerDelegate
+
+    public func documentCameraViewController(_ controller: VNDocumentCameraViewController, didFinishWith scan: VNDocumentCameraScan) {
+        var images: [UIImage] = []
+        for i in 0 ..< scan.pageCount {
+            images.append(scan.imageOfPage(at: i))
+        }
+        processSelectedImages(images)
         presentingController?.dismiss(animated: true)
     }
 
@@ -89,5 +146,61 @@ public class CunningDocumentScannerPlugin: NSObject, FlutterPlugin, VNDocumentCa
     public func documentCameraViewController(_ controller: VNDocumentCameraViewController, didFailWithError error: Error) {
         resultChannel?(FlutterError(code: "ERROR", message: error.localizedDescription, details: nil))
         presentingController?.dismiss(animated: true)
+    }
+
+    // MARK: - UIImagePickerControllerDelegate
+
+    public func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
+        picker.dismiss(animated: true)
+        
+        guard let image = info[.originalImage] as? UIImage else {
+            resultChannel?(nil)
+            return
+        }
+        
+        processSelectedImages([image])
+    }
+
+    public func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
+        picker.dismiss(animated: true)
+        resultChannel?(nil)
+    }
+}
+
+// MARK: - PHPickerViewControllerDelegate
+
+@available(iOS 14.0, *)
+extension CunningDocumentScannerPlugin: PHPickerViewControllerDelegate {
+    public func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
+        picker.dismiss(animated: true)
+        
+        if results.isEmpty {
+            resultChannel?(nil)
+            return
+        }
+        
+        let dispatchGroup = DispatchGroup()
+        var images: [UIImage] = Array(repeating: UIImage(), count: results.count)
+        
+        for (index, result) in results.enumerated() {
+            if result.itemProvider.canLoadObject(ofClass: UIImage.self) {
+                dispatchGroup.enter()
+                result.itemProvider.loadObject(ofClass: UIImage.self) { (object, error) in
+                    if let image = object as? UIImage {
+                        images[index] = image
+                    }
+                    dispatchGroup.leave()
+                }
+            }
+        }
+        
+        dispatchGroup.notify(queue: .main) {
+            let validImages = images.filter { $0.size.width > 0 }
+            if validImages.isEmpty {
+                self.resultChannel?(nil)
+            } else {
+                self.processSelectedImages(validImages)
+            }
+        }
     }
 }

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/CunningDocumentScannerPlugin.swift
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/CunningDocumentScannerPlugin.swift
@@ -6,11 +6,18 @@ import PDFKit
 import Photos
 import PhotosUI
 
-@available(iOS 13.0, *)
 public class CunningDocumentScannerPlugin: NSObject, FlutterPlugin, VNDocumentCameraViewControllerDelegate, UIImagePickerControllerDelegate, UINavigationControllerDelegate {
     var resultChannel: FlutterResult?
     var presentingController: VNDocumentCameraViewController?
     var scannerOptions = CunningScannerOptions()
+
+    var rootViewController: UIViewController? {
+        let keyWindow = UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .flatMap { $0.windows }
+            .first { $0.isKeyWindow } ?? (UIApplication.shared.delegate?.window ?? nil)
+        return keyWindow?.rootViewController
+    }
 
     public static func register(with registrar: FlutterPluginRegistrar) {
         let channel = FlutterMethodChannel(name: "cunning_document_scanner", binaryMessenger: registrar.messenger())
@@ -25,27 +32,37 @@ public class CunningDocumentScannerPlugin: NSObject, FlutterPlugin, VNDocumentCa
         }
 
         scannerOptions = CunningScannerOptions.fromArguments(args: call.arguments)
-        let presentedVC = UIApplication.shared.keyWindow?.rootViewController
+        let presentedVC = rootViewController
         resultChannel = result
 
         if scannerOptions.isGalleryImportAllowed {
+            let labelCamera = getLocalizedOption("cunning_document_scanner_camera", defaultValue: "Camera")
+            let labelGallery = getLocalizedOption("cunning_document_scanner_gallery", defaultValue: "Gallery")
+            let labelCancel = getLocalizedOption("cunning_document_scanner_cancel", defaultValue: "Cancel")
             let alertController = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+            alertController.view.tintColor = .systemBlue
             
-            let cameraAction = UIAlertAction(title: "Camera", style: .default) { _ in
+            let cameraAction = UIAlertAction(title: labelCamera, style: .default) { _ in
                 self.openCamera(from: presentedVC)
             }
-            let galleryAction = UIAlertAction(title: "Gallery", style: .default) { _ in
+            cameraAction.setValue(UIColor.systemBlue, forKey: "titleTextColor")
+
+            let galleryAction = UIAlertAction(title: labelGallery, style: .default) { _ in
                 self.openGallery(from: presentedVC)
             }
-            let cancelAction = UIAlertAction(title: "Cancel", style: .cancel) { _ in
+            galleryAction.setValue(UIColor.systemBlue, forKey: "titleTextColor")
+
+            let cancelAction = UIAlertAction(title: labelCancel, style: .cancel) { _ in
                 self.resultChannel?(nil)
             }
+            cancelAction.setValue(UIColor.systemRed, forKey: "titleTextColor")
             
             alertController.addAction(cameraAction)
             alertController.addAction(galleryAction)
             alertController.addAction(cancelAction)
             
-            if let popoverController = alertController.popoverPresentationController {
+            if UIDevice.current.userInterfaceIdiom == .pad,
+               let popoverController = alertController.popoverPresentationController {
                 popoverController.sourceView = presentedVC?.view
                 popoverController.sourceRect = CGRect(x: presentedVC?.view.bounds.midX ?? 0, y: presentedVC?.view.bounds.midY ?? 0, width: 0, height: 0)
                 popoverController.permittedArrowDirections = []
@@ -87,6 +104,30 @@ public class CunningDocumentScannerPlugin: NSObject, FlutterPlugin, VNDocumentCa
     func getDocumentsDirectory() -> URL {
         let paths = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)
         return paths[0]
+    }
+
+    func getLocalizedOption(_ key: String, defaultValue: String) -> String {
+        let mainBundleValue = Bundle.main.localizedString(forKey: key, value: nil, table: nil)
+        if mainBundleValue != key {
+            return mainBundleValue
+        }
+        #if SWIFT_PACKAGE
+        let pluginBundle = Bundle.module
+        #else
+        let pluginBundle = Bundle(for: CunningDocumentScannerPlugin.self)
+        #endif
+
+        var resolvedBundle = pluginBundle
+        for language in Locale.preferredLanguages {
+            let baseLanguage = language.components(separatedBy: "-").first ?? language
+            if let path = pluginBundle.path(forResource: baseLanguage, ofType: "lproj"),
+               let langBundle = Bundle(path: path) {
+                resolvedBundle = langBundle
+                break
+            }
+        }
+
+        return resolvedBundle.localizedString(forKey: key, value: defaultValue, table: nil)
     }
 
     func processSelectedImages(_ images: [UIImage]) {

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/CunningScannerOptions.swift
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/CunningScannerOptions.swift
@@ -9,17 +9,20 @@ struct CunningScannerOptions {
     let imageFormat: CunningScannerImageFormat
     let jpgCompressionQuality: Double
     let asPdf: Bool
+    let isGalleryImportAllowed: Bool
 
     init() {
         self.imageFormat = .png
         self.jpgCompressionQuality = 1.0
         self.asPdf = false
+        self.isGalleryImportAllowed = false
     }
 
-    init(imageFormat: CunningScannerImageFormat, jpgCompressionQuality: Double, asPdf: Bool) {
+    init(imageFormat: CunningScannerImageFormat, jpgCompressionQuality: Double, asPdf: Bool, isGalleryImportAllowed: Bool) {
         self.imageFormat = imageFormat
         self.jpgCompressionQuality = jpgCompressionQuality
         self.asPdf = asPdf
+        self.isGalleryImportAllowed = isGalleryImportAllowed
     }
 
     static func fromArguments(args: Any?) -> CunningScannerOptions {
@@ -28,6 +31,7 @@ struct CunningScannerOptions {
         }
 
         let asPdf = (arguments["asPdf"] as? Bool) ?? false
+        let isGalleryImportAllowed = (arguments["isGalleryImportAllowed"] as? Bool) ?? false
         let scannerOptionsDict = arguments["iosScannerOptions"] as? [String: Any]
         let imageFormat = (scannerOptionsDict?["imageFormat"] as? String) ?? "png"
         let jpgCompressionQuality = (scannerOptionsDict?["jpgCompressionQuality"] as? Double) ?? 1.0
@@ -35,7 +39,8 @@ struct CunningScannerOptions {
         return CunningScannerOptions(
             imageFormat: CunningScannerImageFormat(rawValue: imageFormat) ?? .png,
             jpgCompressionQuality: jpgCompressionQuality,
-            asPdf: asPdf
+            asPdf: asPdf,
+            isGalleryImportAllowed: isGalleryImportAllowed
         )
     }
 }

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/ar.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/ar.lproj/Localizable.strings
@@ -1,0 +1,3 @@
+"cunning_document_scanner_camera" = "الكاميرا";
+"cunning_document_scanner_gallery" = "مكتبة الصور";
+"cunning_document_scanner_cancel" = "إلغاء";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/ca.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/ca.lproj/Localizable.strings
@@ -1,0 +1,3 @@
+"cunning_document_scanner_camera" = "Càmera";
+"cunning_document_scanner_gallery" = "Biblioteca de fotos";
+"cunning_document_scanner_cancel" = "Cancel·lar";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/cs.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/cs.lproj/Localizable.strings
@@ -1,0 +1,3 @@
+"cunning_document_scanner_camera" = "Fotoaparát";
+"cunning_document_scanner_gallery" = "Knihovna fotografií";
+"cunning_document_scanner_cancel" = "Zrušit";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/da.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/da.lproj/Localizable.strings
@@ -1,0 +1,3 @@
+"cunning_document_scanner_camera" = "Kamera";
+"cunning_document_scanner_gallery" = "Fotobibliotek";
+"cunning_document_scanner_cancel" = "Annuller";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/de.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/de.lproj/Localizable.strings
@@ -1,0 +1,3 @@
+"cunning_document_scanner_camera" = "Kamera";
+"cunning_document_scanner_gallery" = "Fotomediathek";
+"cunning_document_scanner_cancel" = "Abbrechen";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/el.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/el.lproj/Localizable.strings
@@ -1,0 +1,3 @@
+"cunning_document_scanner_camera" = "Κάμερα";
+"cunning_document_scanner_gallery" = "Βιβλιοθήκη φωτογραφιών";
+"cunning_document_scanner_cancel" = "Ακύρωση";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/en.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/en.lproj/Localizable.strings
@@ -1,0 +1,3 @@
+"cunning_document_scanner_camera" = "Camera";
+"cunning_document_scanner_gallery" = "Photo Library";
+"cunning_document_scanner_cancel" = "Cancel";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/es.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/es.lproj/Localizable.strings
@@ -1,0 +1,3 @@
+"cunning_document_scanner_camera" = "Cámara";
+"cunning_document_scanner_gallery" = "Fototeca";
+"cunning_document_scanner_cancel" = "Cancelar";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/fi.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/fi.lproj/Localizable.strings
@@ -1,0 +1,3 @@
+"cunning_document_scanner_camera" = "Kamera";
+"cunning_document_scanner_gallery" = "Kuvakirjasto";
+"cunning_document_scanner_cancel" = "Peruuta";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/fr.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/fr.lproj/Localizable.strings
@@ -1,0 +1,3 @@
+"cunning_document_scanner_camera" = "Appareil photo";
+"cunning_document_scanner_gallery" = "Photothèque";
+"cunning_document_scanner_cancel" = "Annuler";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/he.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/he.lproj/Localizable.strings
@@ -1,0 +1,3 @@
+"cunning_document_scanner_camera" = "מצלמה";
+"cunning_document_scanner_gallery" = "ספריית תמונות";
+"cunning_document_scanner_cancel" = "ביטول";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/hi.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/hi.lproj/Localizable.strings
@@ -1,0 +1,3 @@
+"cunning_document_scanner_camera" = "कैमरा";
+"cunning_document_scanner_gallery" = "फ़ोटो लाइब्रेरी";
+"cunning_document_scanner_cancel" = "रद्द करें";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/id.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/id.lproj/Localizable.strings
@@ -1,0 +1,3 @@
+"cunning_document_scanner_camera" = "Kamera";
+"cunning_document_scanner_gallery" = "Perpustakaan Foto";
+"cunning_document_scanner_cancel" = "Batal";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/it.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/it.lproj/Localizable.strings
@@ -1,0 +1,3 @@
+"cunning_document_scanner_camera" = "Fotocamera";
+"cunning_document_scanner_gallery" = "Libreria foto";
+"cunning_document_scanner_cancel" = "Annulla";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/ja.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/ja.lproj/Localizable.strings
@@ -1,0 +1,3 @@
+"cunning_document_scanner_camera" = "カメラ";
+"cunning_document_scanner_gallery" = "写真ライブラリ";
+"cunning_document_scanner_cancel" = "キャンセル";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/ko.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/ko.lproj/Localizable.strings
@@ -1,0 +1,3 @@
+"cunning_document_scanner_camera" = "카메라";
+"cunning_document_scanner_gallery" = "사진 보관함";
+"cunning_document_scanner_cancel" = "취소";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/nb.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/nb.lproj/Localizable.strings
@@ -1,0 +1,3 @@
+"cunning_document_scanner_camera" = "Kamera";
+"cunning_document_scanner_gallery" = "Bildebibliotek";
+"cunning_document_scanner_cancel" = "Avbryt";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/nl.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/nl.lproj/Localizable.strings
@@ -1,0 +1,3 @@
+"cunning_document_scanner_camera" = "Camera";
+"cunning_document_scanner_gallery" = "Fotobibliotheek";
+"cunning_document_scanner_cancel" = "Annuleren";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/pl.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/pl.lproj/Localizable.strings
@@ -1,0 +1,3 @@
+"cunning_document_scanner_camera" = "Aparat";
+"cunning_document_scanner_gallery" = "Biblioteka zdjęć";
+"cunning_document_scanner_cancel" = "Anuluj";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/pt.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/pt.lproj/Localizable.strings
@@ -1,0 +1,3 @@
+"cunning_document_scanner_camera" = "Câmera";
+"cunning_document_scanner_gallery" = "Fototeca";
+"cunning_document_scanner_cancel" = "Cancelar";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/ro.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/ro.lproj/Localizable.strings
@@ -1,0 +1,3 @@
+"cunning_document_scanner_camera" = "Cameră";
+"cunning_document_scanner_gallery" = "Librărie foto";
+"cunning_document_scanner_cancel" = "Anulează";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/ru.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/ru.lproj/Localizable.strings
@@ -1,0 +1,3 @@
+"cunning_document_scanner_camera" = "Камера";
+"cunning_document_scanner_gallery" = "Медиатека";
+"cunning_document_scanner_cancel" = "Отмена";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/sv.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/sv.lproj/Localizable.strings
@@ -1,0 +1,3 @@
+"cunning_document_scanner_camera" = "Kamera";
+"cunning_document_scanner_gallery" = "Bildbibliotek";
+"cunning_document_scanner_cancel" = "Avbryt";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/th.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/th.lproj/Localizable.strings
@@ -1,0 +1,3 @@
+"cunning_document_scanner_camera" = "กล้อง";
+"cunning_document_scanner_gallery" = "คลังรูปภาพ";
+"cunning_document_scanner_cancel" = "ยกเลิก";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/tr.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/tr.lproj/Localizable.strings
@@ -1,0 +1,3 @@
+"cunning_document_scanner_camera" = "Kamera";
+"cunning_document_scanner_gallery" = "Fotoğraf Kitaplığı";
+"cunning_document_scanner_cancel" = "İptal";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/uk.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/uk.lproj/Localizable.strings
@@ -1,0 +1,3 @@
+"cunning_document_scanner_camera" = "Камера";
+"cunning_document_scanner_gallery" = "Бібліотека фото";
+"cunning_document_scanner_cancel" = "Скасувати";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/vi.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/vi.lproj/Localizable.strings
@@ -1,0 +1,3 @@
+"cunning_document_scanner_camera" = "Máy ảnh";
+"cunning_document_scanner_gallery" = "Thư viện ảnh";
+"cunning_document_scanner_cancel" = "Hủy";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/zh-Hans.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/zh-Hans.lproj/Localizable.strings
@@ -1,0 +1,3 @@
+"cunning_document_scanner_camera" = "相机";
+"cunning_document_scanner_gallery" = "照片图库";
+"cunning_document_scanner_cancel" = "取消";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/zh-Hant.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/zh-Hant.lproj/Localizable.strings
@@ -1,0 +1,3 @@
+"cunning_document_scanner_camera" = "相機";
+"cunning_document_scanner_gallery" = "照片圖庫";
+"cunning_document_scanner_cancel" = "取消";

--- a/lib/src/cunning_document_scanner.dart
+++ b/lib/src/cunning_document_scanner.dart
@@ -22,6 +22,7 @@ class CunningDocumentScanner {
   /// [isGalleryImportAllowed] is a flag that allows the user to import images from the gallery.
   /// [androidScannerMode] controls the ML Kit scanner mode on Android only.
   /// [iosScannerOptions] is a set of options for the iOS scanner.
+  /// [asPdf] is a flag that indicates if the scanned pages should be compiled and returned as a single PDF file path.
   ///
   /// Returns a list of paths to the scanned images, or null if the user cancels the operation.
   static Future<List<String>?> getPictures({


### PR DESCRIPTION
This PR adds support for 'isGalleryImportAllowed' on iOS, bringing it to feature parity with Android.

- Fixes: https://github.com/jachzen/cunning_document_scanner/issues/122.
- Fixes: https://github.com/jachzen/cunning_document_scanner/issues/118.
- Fixes: https://github.com/jachzen/cunning_document_scanner/issues/89.
- Fixes: https://github.com/jachzen/cunning_document_scanner/issues/78.
- Fixes: https://github.com/jachzen/cunning_document_scanner/issues/77.

### Changes:
* Updated 'CunningScannerOptions' in Swift to parse 'isGalleryImportAllowed'.
* Implemented 'PHPickerViewController' for iOS 14+ supporting multi-selection from photo library.
* Implemented 'UIImagePickerController' fallback for iOS 13.
* Consolidated image/PDF creation logic into a shared helper 'processSelectedImages' used by both camera delegates and gallery pickers.
* Added dynamic UI toggle in the example app for gallery import.