### PR TITLE
fix(android): make HMS ML Kit dependencies optional to resolve allowBackup conflict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.5.1
+### Android
+* Made HMS ML Kit dependencies optional using `compileOnly` and dynamic reflection to resolve `allowBackup` manifest merger conflicts (fixes #144).
+* Prevented bundling of Huawei HMS libraries in the final APK by default, reducing build sizes for non-HMS projects.
+
 ## 2.5.0
 ### General
 * Introduced `ScannerSource` enum to specify the source of document images: `camera`, `gallery`, or `cameraAndGallery`.

--- a/README.md
+++ b/README.md
@@ -118,6 +118,51 @@ There are some features in Android that allow you to adjust the scanner that wil
    );
 ```
 
+
+#### Optional Huawei HMS ML Kit Support
+
+Starting from version 2.5.0, this plugin supports automatic document edge detection on Huawei Mobile Services (HMS) devices (devices without Google Play Services, such as newer Huawei/Honor phones) using Huawei's ML Kit Document Skew Correction.
+
+To keep the plugin lightweight and avoid manifest merger conflicts (`allowBackup` errors) for non-Huawei projects, HMS dependencies are marked as `compileOnly` and are **disabled by default**.
+
+To enable HMS ML Kit support in your application:
+
+1. Add the Huawei Maven repository to your root project's `android/build.gradle` (or `android/build.gradle.kts`):
+
+   ```groovy
+   allprojects {
+       repositories {
+           google()
+           mavenCentral()
+           maven { url 'https://developer.huawei.com/repo/' }
+       }
+   }
+   ```
+
+2. Add the Huawei ML Kit Document Skew Correction dependencies in your `android/app/build.gradle` (or `android/app/build.gradle.kts`):
+
+   ```groovy
+   dependencies {
+       // ... other dependencies
+       implementation 'com.huawei.hms:ml-computer-vision-documentskew:3.11.0.301'
+       implementation 'com.huawei.hms:ml-computer-vision-documentskew-model:3.7.0.301'
+   }
+   ```
+
+3. Note that since Huawei's ML Kit library defines `android:allowBackup="false"`, you will need to add `tools:replace="android:allowBackup"` to the `<application>` tag in your `android/app/src/main/AndroidManifest.xml` to avoid a manifest merger conflict:
+
+   ```xml
+   <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+       xmlns:tools="http://schemas.android.com/tools">
+       <application
+           android:allowBackup="true"
+           tools:replace="android:allowBackup"
+           ... >
+           ...
+       </application>
+   </manifest>
+   ```
+
 ### iOS Specific
 
 On iOS it is possible to configure which image format should be used to save of the document scans. Available options are PNG (default) or JPEG. In certain situations the JPEG format could drastically reduce the file size of the final scan. If you choose to use JPEG you can also specify a compression quality, where 0.0 is highest compression (lowest quality) and 1.0 (default) is the lowest compression (highest quality). Example usage is:

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -49,6 +49,6 @@ plugins.withId("org.jetbrains.kotlin.android") {
 
 dependencies {
     implementation("com.google.android.gms:play-services-mlkit-document-scanner:16.0.0")
-    implementation("com.huawei.hms:ml-computer-vision-documentskew:3.11.0.301")
-    implementation("com.huawei.hms:ml-computer-vision-documentskew-model:3.7.0.301")
+    compileOnly("com.huawei.hms:ml-computer-vision-documentskew:3.11.0.301")
+    compileOnly("com.huawei.hms:ml-computer-vision-documentskew-model:3.7.0.301")
 }

--- a/android/src/main/kotlin/biz/cunning/cunning_document_scanner/fallback/DocumentScannerActivity.kt
+++ b/android/src/main/kotlin/biz/cunning/cunning_document_scanner/fallback/DocumentScannerActivity.kt
@@ -24,9 +24,6 @@ import biz.cunning.cunning_document_scanner.fallback.utils.CameraUtil
 import biz.cunning.cunning_document_scanner.fallback.utils.FileUtil
 import biz.cunning.cunning_document_scanner.fallback.utils.ImageUtil
 import java.io.File
-import com.huawei.hms.mlsdk.common.MLFrame
-import com.huawei.hms.mlsdk.dsc.MLDocumentSkewCorrectionAnalyzerFactory
-import com.huawei.hms.mlsdk.dsc.MLDocumentSkewCorrectionAnalyzerSetting
 import android.content.pm.PackageManager
 /**
  * This class contains the main document scanner code. It opens the camera, lets the user
@@ -258,61 +255,33 @@ class DocumentScannerActivity : AppCompatActivity() {
         }
     }
 
+    private fun isHmsLibraryAvailable(): Boolean {
+        return try {
+            Class.forName("com.huawei.hms.mlsdk.dsc.MLDocumentSkewCorrectionAnalyzerFactory")
+            true
+        } catch (e: ClassNotFoundException) {
+            false
+        }
+    }
+
     private fun detectCorners(photo: Bitmap, onComplete: (Quad) -> Unit) {
-        if (isHmsAvailable()) {
+        if (isHmsAvailable() && isHmsLibraryAvailable()) {
             try {
-                val setting = MLDocumentSkewCorrectionAnalyzerSetting.Factory().create()
-                val analyzer = MLDocumentSkewCorrectionAnalyzerFactory.getInstance()
-                    .getDocumentSkewCorrectionAnalyzer(setting)
-                val frame = MLFrame.fromBitmap(photo)
-
-                analyzer.asyncDocumentSkewDetect(frame)
-                    .addOnSuccessListener { result: com.huawei.hms.mlsdk.dsc.MLDocumentSkewDetectResult? ->
-                        if (result != null) {
-                            val lt = result.leftTopPosition
-                            val rt = result.rightTopPosition
-                            val lb = result.leftBottomPosition
-                            val rb = result.rightBottomPosition
-
-                            if (lt != null && rt != null && lb != null && rb != null) {
-                                val tl = Point(lt.x.toDouble(), lt.y.toDouble())
-                                val tr = Point(rt.x.toDouble(), rt.y.toDouble())
-                                val bl = Point(lb.x.toDouble(), lb.y.toDouble())
-                                val br = Point(rb.x.toDouble(), rb.y.toDouble())
-                                val sortedQuad = sortPoints(listOf(tl, tr, bl, br))
-                                analyzer.stop()
-                                onComplete(sortedQuad)
-                                return@addOnSuccessListener
-                            }
-                        }
-                        analyzer.stop()
+                val detectorClass = Class.forName("biz.cunning.cunning_document_scanner.fallback.HmsEdgeDetector")
+                val detector = detectorClass.getDeclaredConstructor().newInstance() as EdgeDetector
+                detector.detect(photo) { detectedQuad ->
+                    if (detectedQuad != null) {
+                        onComplete(detectedQuad)
+                    } else {
                         onComplete(getDefaultCorners(photo))
                     }
-                    .addOnFailureListener {
-                        try {
-                            analyzer.stop()
-                        } catch (e: Exception) {}
-                        onComplete(getDefaultCorners(photo))
-                    }
+                }
                 return
             } catch (e: Exception) {
-                // Fallback to default corners if HMS ML Kit fails to initialize/analyze
+                android.util.Log.e("DocumentScannerActivity", "Error loading HmsEdgeDetector dynamically", e)
             }
         }
         onComplete(getDefaultCorners(photo))
-    }
-
-    private fun sortPoints(points: List<Point>): Quad {
-        val sortedByY = points.sortedBy { it.y }
-        val topPoints = sortedByY.take(2).sortedBy { it.x }
-        val bottomPoints = sortedByY.takeLast(2).sortedBy { it.x }
-
-        val topLeft = topPoints[0]
-        val topRight = topPoints[1]
-        val bottomLeft = bottomPoints[0]
-        val bottomRight = bottomPoints[1]
-
-        return Quad(topLeft, topRight, bottomRight, bottomLeft)
     }
 
     private fun getDefaultCorners(photo: Bitmap): Quad {

--- a/android/src/main/kotlin/biz/cunning/cunning_document_scanner/fallback/EdgeDetector.kt
+++ b/android/src/main/kotlin/biz/cunning/cunning_document_scanner/fallback/EdgeDetector.kt
@@ -1,0 +1,8 @@
+package biz.cunning.cunning_document_scanner.fallback
+
+import android.graphics.Bitmap
+import biz.cunning.cunning_document_scanner.fallback.models.Quad
+
+interface EdgeDetector {
+    fun detect(photo: Bitmap, onComplete: (Quad?) -> Unit)
+}

--- a/android/src/main/kotlin/biz/cunning/cunning_document_scanner/fallback/HmsEdgeDetector.kt
+++ b/android/src/main/kotlin/biz/cunning/cunning_document_scanner/fallback/HmsEdgeDetector.kt
@@ -1,0 +1,63 @@
+package biz.cunning.cunning_document_scanner.fallback
+
+import android.graphics.Bitmap
+import biz.cunning.cunning_document_scanner.fallback.models.Point
+import biz.cunning.cunning_document_scanner.fallback.models.Quad
+import com.huawei.hms.mlsdk.common.MLFrame
+import com.huawei.hms.mlsdk.dsc.MLDocumentSkewCorrectionAnalyzerFactory
+import com.huawei.hms.mlsdk.dsc.MLDocumentSkewCorrectionAnalyzerSetting
+
+class HmsEdgeDetector : EdgeDetector {
+    override fun detect(photo: Bitmap, onComplete: (Quad?) -> Unit) {
+        try {
+            val setting = MLDocumentSkewCorrectionAnalyzerSetting.Factory().create()
+            val analyzer = MLDocumentSkewCorrectionAnalyzerFactory.getInstance()
+                .getDocumentSkewCorrectionAnalyzer(setting)
+            val frame = MLFrame.fromBitmap(photo)
+
+            analyzer.asyncDocumentSkewDetect(frame)
+                .addOnSuccessListener { result: com.huawei.hms.mlsdk.dsc.MLDocumentSkewDetectResult? ->
+                    if (result != null) {
+                        val lt = result.leftTopPosition
+                        val rt = result.rightTopPosition
+                        val lb = result.leftBottomPosition
+                        val rb = result.rightBottomPosition
+
+                        if (lt != null && rt != null && lb != null && rb != null) {
+                            val tl = Point(lt.x.toDouble(), lt.y.toDouble())
+                            val tr = Point(rt.x.toDouble(), rt.y.toDouble())
+                            val bl = Point(lb.x.toDouble(), lb.y.toDouble())
+                            val br = Point(rb.x.toDouble(), rb.y.toDouble())
+                            val sortedQuad = sortPoints(listOf(tl, tr, bl, br))
+                            analyzer.stop()
+                            onComplete(sortedQuad)
+                            return@addOnSuccessListener
+                        }
+                    }
+                    analyzer.stop()
+                    onComplete(null)
+                }
+                .addOnFailureListener {
+                    try {
+                        analyzer.stop()
+                    } catch (e: Exception) {}
+                    onComplete(null)
+                }
+        } catch (e: Exception) {
+            onComplete(null)
+        }
+    }
+
+    private fun sortPoints(points: List<Point>): Quad {
+        val sortedByY = points.sortedBy { it.y }
+        val topPoints = sortedByY.take(2).sortedBy { it.x }
+        val bottomPoints = sortedByY.takeLast(2).sortedBy { it.x }
+
+        val topLeft = topPoints[0]
+        val topRight = topPoints[1]
+        val bottomLeft = bottomPoints[0]
+        val bottomRight = bottomPoints[1]
+
+        return Quad(topLeft, topRight, bottomRight, bottomLeft)
+    }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cunning_document_scanner
 description: A document scanner plugin for flutter. Scan and crop automatically on iOS and Android.
-version: 2.5.0
+version: 2.5.1
 homepage: https://cunning.biz
 repository: https://github.com/jachzen/cunning_document_scanner
 


### PR DESCRIPTION
Closes #144

### Proposed Changes
- Switched HMS ML Kit dependencies from `implementation` to `compileOnly`.
- Created `EdgeDetector` interface and `HmsEdgeDetector` helper to encapsulate HMS SDK dependencies.
- Refactored `DocumentScannerActivity` to dynamically load the HMS detector via reflection.
- Updated `README.md` to document how users can optionally include HMS support in their applications.