### PR TITLE
feat(ios): implement manual cropping for gallery images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 2.7.0
+### iOS
+* Added manual document cropper for gallery-imported images (`ScannerSource.gallery`), resolving the limitation where gallery images could not be manually cropped before export.
+* Implemented a circular `MagnifierView` precision zoom lens centered over handles during touch dragging, providing pixel-perfect corner positioning.
+* Added a cancel confirmation dialog to prevent accidental data loss in multi-page scanning.
+* Fixed rotate button behavior to properly map cropping coordinates 90 degrees clockwise without losing user progress.
+* Optimized image loading and processing:
+  * Offloaded heavy image orientation fixes (`fixedOrientation()`) and perspective correction filters to background threads.
+  * Wrapped background processing calls in `autoreleasepool` blocks to force immediate memory deallocation and avoid OOM crashes.
+  * Downscaled imported gallery images to a maximum of 2048px on load to prevent concurrent memory spikes.
+  * Replaced CPU-intensive rotation with instant metadata orientation changes.
+* Added translations for the new cropper discard options across all 29 localized languages.
+
 ## 2.6.0
 ### Android
 * Removed HMS (Huawei Mobile Services) support entirely to ensure 16 KB page-size compatibility on Android 15+ (fixes #146).

--- a/android/src/main/kotlin/biz/cunning/cunning_document_scanner/CunningDocumentScannerPlugin.kt
+++ b/android/src/main/kotlin/biz/cunning/cunning_document_scanner/CunningDocumentScannerPlugin.kt
@@ -26,30 +26,41 @@ import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
 import io.flutter.plugin.common.PluginRegistry
 
-
-/** CunningDocumentScannerPlugin */
+/// Main Android plugin class for cunning_document_scanner.
+/// Handles Flutter MethodChannel calls, Google Play Services (GMS) document scanner triggers,
+/// photo picking from gallery, and fallback cropping flows.
 class CunningDocumentScannerPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
+    
+    /// Delegate to handle activity result callbacks.
     private var delegate: PluginRegistry.ActivityResultListener? = null
+    
+    /// Binding associated with the current activity.
     private var binding: ActivityPluginBinding? = null
+    
+    /// The pending Flutter Result object to return scanned images paths back.
     private var pendingResult: Result? = null
+    
+    /// Flag to check if scanned document must be exported as PDF.
     private var asPdf: Boolean = false
+    
+    /// The current Android activity instance.
     private lateinit var activity: Activity
+    
+    /// Request code constants for starting activities.
     private val START_DOCUMENT_ACTIVITY: Int = 0x362738
     private val START_DOCUMENT_FB_ACTIVITY: Int = 0x362737
     private val START_GALLERY_PICKER: Int = 0x362736
 
-
-    /// The MethodChannel that will the communication between Flutter and native Android
-    ///
-    /// This local reference serves to register the plugin with the Flutter Engine and unregister it
-    /// when the Flutter Engine is detached from the Activity
+    /// The MethodChannel that handles communication between Flutter and native Android.
     private lateinit var channel: MethodChannel
 
+    /// Called when the plugin is attached to the Flutter Engine.
     override fun onAttachedToEngine(flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
         channel = MethodChannel(flutterPluginBinding.binaryMessenger, "cunning_document_scanner")
         channel.setMethodCallHandler(this)
     }
 
+    /// Handles MethodChannel method calls from Dart/Flutter.
     override fun onMethodCall(call: MethodCall, result: Result) {
         if (call.method == "getPictures") {
             val noOfPages = call.argument<Int>("noOfPages") ?: 50
@@ -72,17 +83,18 @@ class CunningDocumentScannerPlugin : FlutterPlugin, MethodCallHandler, ActivityA
         }
     }
 
-
+    /// Called when the plugin is detached from the Flutter Engine.
     override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
         channel.setMethodCallHandler(null)
     }
 
+    /// Called when the plugin is attached to the host Activity.
     override fun onAttachedToActivity(binding: ActivityPluginBinding) {
         this.activity = binding.activity
-
         addActivityResultListener(binding)
     }
 
+    /// Starts the Android system gallery image picker intent.
     private fun startGalleryPicker() {
         val intent = Intent(Intent.ACTION_GET_CONTENT).apply {
             type = "image/*"
@@ -95,6 +107,7 @@ class CunningDocumentScannerPlugin : FlutterPlugin, MethodCallHandler, ActivityA
         }
     }
 
+    /// Registers the ActivityResultListener to handle image selection and scanning result intents.
     private fun addActivityResultListener(binding: ActivityPluginBinding) {
         this.binding = binding
         if (this.delegate == null) {
@@ -145,13 +158,11 @@ class CunningDocumentScannerPlugin : FlutterPlugin, MethodCallHandler, ActivityA
                     android.util.Log.d("CunningScannerPlugin", "Handling START_DOCUMENT_ACTIVITY (GMS)")
                     when (resultCode) {
                         Activity.RESULT_OK -> {
-                            // check for errors
                             val error = data?.extras?.getString("error")
                             android.util.Log.d("CunningScannerPlugin", "GMS error extra: $error")
                             if (error != null) {
                                 pendingResult?.error("ERROR", "error - $error", null)
                             } else {
-                                 // get an array with scanned document file paths
                                  val scanningResult = data?.extras?.let { extras ->
                                      androidx.core.os.BundleCompat.getParcelable(
                                          extras,
@@ -173,7 +184,6 @@ class CunningDocumentScannerPlugin : FlutterPlugin, MethodCallHandler, ActivityA
                                         it.imageUri.toString().removePrefix("file://")
                                     }?.toList()
                                     android.util.Log.d("CunningScannerPlugin", "GMS success response: $successResponse")
-                                    // trigger the success event handler with an array of cropped images
                                     pendingResult?.success(successResponse)
                                 }
                             }
@@ -182,7 +192,6 @@ class CunningDocumentScannerPlugin : FlutterPlugin, MethodCallHandler, ActivityA
 
                         Activity.RESULT_CANCELED -> {
                             android.util.Log.d("CunningScannerPlugin", "GMS scanner cancelled")
-                            // user closed camera
                             pendingResult?.success(emptyList<String>())
                             handled = true
                         }
@@ -192,13 +201,11 @@ class CunningDocumentScannerPlugin : FlutterPlugin, MethodCallHandler, ActivityA
                     android.util.Log.d("CunningScannerPlugin", "Handling START_DOCUMENT_FB_ACTIVITY (Fallback/HMS)")
                     when (resultCode) {
                         Activity.RESULT_OK -> {
-                            // check for errors
                             val error = data?.extras?.getString("error")
                             android.util.Log.d("CunningScannerPlugin", "Cropper error extra: $error")
                             if (error != null) {
                                 pendingResult?.error("ERROR", "error - $error", null)
                             } else {
-                                // get an array with scanned document file paths
                                 val croppedImageResults =
                                     data?.getStringArrayListExtra("croppedImageResults")?.toList()
                                         ?: let {
@@ -209,8 +216,6 @@ class CunningDocumentScannerPlugin : FlutterPlugin, MethodCallHandler, ActivityA
                                         }
                                 android.util.Log.d("CunningScannerPlugin", "Cropped image results: $croppedImageResults")
 
-                                // return a list of file paths
-                                // removing file uri prefix as Flutter file will have problems with it
                                 val successResponse = croppedImageResults.map {
                                     it.removePrefix("file://")
                                 }.toList()
@@ -225,7 +230,6 @@ class CunningDocumentScannerPlugin : FlutterPlugin, MethodCallHandler, ActivityA
                                         pendingResult?.error("ERROR", "Failed to create PDF from fallback scanner: ${e.message}", null)
                                     }
                                 } else {
-                                    // trigger the success event handler with an array of cropped images
                                     pendingResult?.success(successResponse)
                                 }
                             }
@@ -234,7 +238,6 @@ class CunningDocumentScannerPlugin : FlutterPlugin, MethodCallHandler, ActivityA
 
                         Activity.RESULT_CANCELED -> {
                             android.util.Log.d("CunningScannerPlugin", "Cropper cancelled")
-                            // user closed camera
                             pendingResult?.success(emptyList<String>())
                             handled = true
                         }
@@ -255,10 +258,7 @@ class CunningDocumentScannerPlugin : FlutterPlugin, MethodCallHandler, ActivityA
         binding.addActivityResultListener(delegate!!)
     }
 
-
-    /**
-     * create intent to launch document scanner and set custom options
-     */
+    /// Creates an Intent to launch the fallback document scanner activity.
     private fun createDocumentScanIntent(noOfPages: Int): Intent {
         val documentScanIntent = Intent(activity, DocumentScannerActivity::class.java)
 
@@ -270,10 +270,7 @@ class CunningDocumentScannerPlugin : FlutterPlugin, MethodCallHandler, ActivityA
         return documentScanIntent
     }
 
-
-    /**
-     * add document scanner result handler and launch the document scanner
-     */
+    /// Resolves GmsDocumentScannerOptions modes.
     private fun resolveScannerMode(mode: String?): Int {
         return when (mode) {
             "base" -> SCANNER_MODE_BASE
@@ -283,6 +280,7 @@ class CunningDocumentScannerPlugin : FlutterPlugin, MethodCallHandler, ActivityA
         }
     }
 
+    /// Configures GmsDocumentScannerOptions and launches GMS Document Scanner activity.
     private fun startScan(noOfPages: Int, isGalleryImportAllowed: Boolean, scannerMode: Int, asPdf: Boolean) {
         val optionsBuilder = GmsDocumentScannerOptions.Builder()
             .setGalleryImportAllowed(isGalleryImportAllowed)
@@ -300,7 +298,6 @@ class CunningDocumentScannerPlugin : FlutterPlugin, MethodCallHandler, ActivityA
             val scanner = GmsDocumentScanning.getClient(options)
             scanner.getStartScanIntent(activity).addOnSuccessListener {
                 try {
-                    // Use a custom request code for onActivityResult identification
                     activity.startIntentSenderForResult(it, START_DOCUMENT_ACTIVITY, null, 0, 0, 0)
                 } catch (_: IntentSender.SendIntentException) {
                     pendingResult?.error("ERROR", "Failed to start document scanner", null)
@@ -313,6 +310,7 @@ class CunningDocumentScannerPlugin : FlutterPlugin, MethodCallHandler, ActivityA
         }
     }
 
+    /// Opens the fallback manual cropping scanner activity if GMS is unavailable.
     private fun openFallbackScanner(noOfPages: Int) {
         val intent = createDocumentScanIntent(noOfPages)
         try {
@@ -327,9 +325,7 @@ class CunningDocumentScannerPlugin : FlutterPlugin, MethodCallHandler, ActivityA
         }
     }
 
-    override fun onDetachedFromActivityForConfigChanges() {
-
-    }
+    override fun onDetachedFromActivityForConfigChanges() {}
 
     override fun onReattachedToActivityForConfigChanges(binding: ActivityPluginBinding) {
         addActivityResultListener(binding)
@@ -339,6 +335,7 @@ class CunningDocumentScannerPlugin : FlutterPlugin, MethodCallHandler, ActivityA
         removeActivityResultListener()
     }
 
+    /// Removes ActivityResultListener callback registrations.
     private fun removeActivityResultListener() {
         this.delegate?.let { this.binding?.removeActivityResultListener(it) }
     }

--- a/android/src/main/kotlin/biz/cunning/cunning_document_scanner/fallback/DocumentScannerActivity.kt
+++ b/android/src/main/kotlin/biz/cunning/cunning_document_scanner/fallback/DocumentScannerActivity.kt
@@ -25,62 +25,41 @@ import biz.cunning.cunning_document_scanner.fallback.utils.FileUtil
 import biz.cunning.cunning_document_scanner.fallback.utils.ImageUtil
 import java.io.File
 import android.content.pm.PackageManager
-/**
- * This class contains the main document scanner code. It opens the camera, lets the user
- * take a photo of a document (homework paper, business card, etc.), detects document corners,
- * allows user to make adjustments to the detected corners, depending on options, and saves
- * the cropped document. It allows the user to do this for 1 or more documents.
- *
- * @constructor creates document scanner activity
- */
+
+/// This class contains the main document scanner code. It opens the camera, lets the user
+/// take a photo of a document (homework paper, business card, etc.), detects document corners,
+/// allows user to make adjustments to the detected corners, depending on options, and saves
+/// the cropped document. It allows the user to do this for 1 or more documents.
 class DocumentScannerActivity : AppCompatActivity() {
-    /**
-     * @property maxNumDocuments maximum number of documents a user can scan at a time
-     */
+    
+    /// Maximum number of documents a user can scan at a time.
     private var maxNumDocuments = DefaultSetting.MAX_NUM_DOCUMENTS
 
-    /**
-     * @property croppedImageQuality the 0 - 100 quality of the cropped image
-     */
+    /// The 0 - 100 quality of the cropped image.
     private var croppedImageQuality = DefaultSetting.CROPPED_IMAGE_QUALITY
 
-    /**
-     * @property cropperOffsetWhenCornersNotFound if we can't find document corners, we set
-     * corners to image size with a slight margin
-     */
+    /// Default offset margin used when document corners are not detected.
     private val cropperOffsetWhenCornersNotFound = 100.0
 
-    /**
-     * @property document This is the current document. Initially it's null. Once we capture
-     * the photo, and find the corners we update document.
-     */
+    /// Current document being processed. Set once a photo is taken and corners are resolved.
     private var document: Document? = null
 
-    /**
-     * @property documents a list of documents (original photo file path, original photo
-     * dimensions and 4 corner points)
-     */
+    /// List of scanned/cropped documents containing original paths, dimensions, and corners.
     private val documents = mutableListOf<Document>()
 
-    /**
-     * @property cameraUtil gets called with photo file path once user takes photo, or
-     * exits camera
-     */
+    /// Camera utilities callback delegate to handle camera capture success or cancel events.
     private val cameraUtil = CameraUtil(
         this,
         onPhotoCaptureSuccess = {
-            // user takes photo
             originalPhotoPath ->
 
-            // if maxNumDocuments is 3 and this is the 3rd photo, hide the new photo button since
-            // we reach the allowed limit
+            // Hide the add-new-photo button if the documents count reaches max limit minus one
             if (documents.size == maxNumDocuments - 1) {
                 val newPhotoButton: ImageButton = findViewById(R.id.new_photo_button)
                 newPhotoButton.isClickable = false
                 newPhotoButton.visibility = View.INVISIBLE
             }
 
-            // get bitmap from photo file path
             val photo: Bitmap? = try {
                 ImageUtil().getImageFromFilePath(originalPhotoPath)
             } catch (exception: Exception) {
@@ -93,28 +72,20 @@ class DocumentScannerActivity : AppCompatActivity() {
                 return@CameraUtil
             }
 
-            // get default corners for cropping
             detectCorners(photo) { corners ->
                 document = Document(originalPhotoPath, photo.width, photo.height, corners)
 
-                // user is allowed to move corners to make corrections
                 try {
-                    // set preview image height based off of photo dimensions
                     imageView.setImagePreviewBounds(photo, screenWidth, screenHeight)
-
-                    // display original photo, so user can adjust detected corners
                     imageView.setImage(photo)
 
-                    // document corner points are in original image coordinates, so we need to
-                    // scale and move the points to account for blank space (caused by photo and
-                    // photo container having different aspect ratios)
+                    // Map corners from absolute coordinates to preview bounds coordinates
                     val cornersInImagePreviewCoordinates = corners
                         .mapOriginalToPreviewImageCoordinates(
                             imageView.imagePreviewBounds,
                             imageView.imagePreviewBounds.height() / photo.height
                         )
 
-                    // display cropper, and allow user to move corners
                     imageView.setCropper(cornersInImagePreviewCoordinates)
                 } catch (exception: Exception) {
                     finishIntentWithError(
@@ -124,36 +95,24 @@ class DocumentScannerActivity : AppCompatActivity() {
             }
         },
         onCancelPhoto = {
-            // user exits camera
-            // complete document scan if this is the first document since we can't go to crop view
-            // until user takes at least 1 photo
             if (documents.isEmpty()) {
                 onClickCancel()
             }
         }
     )
 
-    /**
-     * @property imageView container with original photo and cropper
-     */
+    /// Container view holding the preview image and draggable crop overlay.
     private lateinit var imageView: ImageCropView
 
-    /**
-     * called when activity is created
-     *
-     * @param savedInstanceState persisted data that maintains state
-     */
+    /// Called when the activity is first created. Sets up UI buttons, handles intent extras,
+    /// and resolves whether to load an initial image URI or launch the camera.
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        // Show cropper, accept crop button, add new document button, and
-        // retake photo button. Since we open the camera in a few lines, the user
-        // doesn't see this until they finish taking a photo
         setContentView(R.layout.activity_image_crop)
         imageView = findViewById(R.id.image_view)
 
         try {
-            // validate maxNumDocuments option, and update default if user sets it
             var userSpecifiedMaxImages: Int? = null
             intent.extras?.get(DocumentScannerExtra.EXTRA_MAX_NUM_DOCUMENTS)?.let {
                 if (it.toString().toIntOrNull() == null) {
@@ -165,7 +124,6 @@ class DocumentScannerActivity : AppCompatActivity() {
                 maxNumDocuments = userSpecifiedMaxImages as Int
             }
 
-            // validate croppedImageQuality option, and update value if user sets it
             intent.extras?.get(DocumentScannerExtra.EXTRA_CROPPED_IMAGE_QUALITY)?.let {
                 if (it !is Int || it < 0 || it > 100) {
                     throw Exception(
@@ -182,8 +140,6 @@ class DocumentScannerActivity : AppCompatActivity() {
             return
         }
 
-        // set click event handlers for new document button, accept and crop document button,
-        // and retake document photo button
         val newPhotoButton: ImageButton = findViewById(R.id.new_photo_button)
         val completeDocumentScanButton: ImageButton = findViewById(
             R.id.complete_document_scan_button
@@ -235,7 +191,6 @@ class DocumentScannerActivity : AppCompatActivity() {
                 finishIntentWithError("error loading image to crop: ${exception.message}")
             }
         } else {
-            // open camera, so user can snap document photo
             try {
                 openCamera()
             } catch (exception: Exception) {
@@ -246,10 +201,12 @@ class DocumentScannerActivity : AppCompatActivity() {
         }
     }
 
+    /// Resolves document corners asynchronously. Defaults to inset bounding box.
     private fun detectCorners(photo: Bitmap, onComplete: (Quad) -> Unit) {
         onComplete(getDefaultCorners(photo))
     }
 
+    /// Computes default fallback corner locations with standard inset offsets.
     private fun getDefaultCorners(photo: Bitmap): Quad {
         return Quad(
             Point(0.0, 0.0).move(
@@ -271,26 +228,15 @@ class DocumentScannerActivity : AppCompatActivity() {
         )
     }
 
-    /**
-     * Set document to null since we're capturing a new document, and open the camera. If the
-     * user captures a photo successfully document gets updated.
-     */
+    /// Resets current document state and launches camera utility intent.
     private fun openCamera() {
         document = null
         cameraUtil.openCamera(documents.size)
     }
 
-    /**
-     * Once user accepts by pressing check button, or by pressing add new document button, add
-     * original photo path and 4 document corners to documents list. If user isn't allowed to
-     * adjust corners, call this automatically.
-     */
+    /// Converts preview coordinates to original image coordinates and adds the document to the list.
     private fun addSelectedCornersAndOriginalPhotoPathToDocuments() {
-        // only add document it's not null (the current document photo capture, and corner
-        // detection are successful)
         document?.let { document ->
-            // convert corners from image preview coordinates to original photo coordinates
-            // (original image is probably bigger than the preview image)
             val cornersInOriginalImageCoordinates = imageView.corners
                 .mapPreviewToOriginalImageCoordinates(
                     imageView.imagePreviewBounds,
@@ -301,54 +247,35 @@ class DocumentScannerActivity : AppCompatActivity() {
         }
     }
 
-    /**
-     * This gets called when a user presses the new document button. Store current photo path
-     * with document corners. Then open the camera, so user can take a photo of the next
-     * page or document
-     */
+    /// Callback triggered by new photo button click.
     private fun onClickNew() {
         addSelectedCornersAndOriginalPhotoPathToDocuments()
         openCamera()
     }
 
-    /**
-     * This gets called when a user presses the done button. Store current photo path with
-     * document corners. Then crop document using corners, and return cropped image paths
-     */
+    /// Callback triggered by complete done button click.
     private fun onClickDone() {
         addSelectedCornersAndOriginalPhotoPathToDocuments()
         cropDocumentAndFinishIntent()
     }
 
-    /**
-     * This gets called when a user presses the retake photo button. The user presses this in
-     * case the original document photo isn't good, and they need to take it again.
-     */
+    /// Callback triggered by retake photo button click. Deletes current captured file and opens camera.
     private fun onClickRetake() {
-        // we're going to retake the photo, so delete the one we just took
         document?.let { document -> File(document.originalPhotoFilePath).delete() }
         openCamera()
     }
 
-    /**
-     * This gets called when a user doesn't want to complete the document scan after starting.
-     * For example a user can quit out of the camera before snapping a photo of the document.
-     */
+    /// Callback triggered by cancel click. Cancels activity and returns cancel result code.
     private fun onClickCancel() {
         setResult(Activity.RESULT_CANCELED)
         finish()
     }
 
-    /**
-     * This crops original document photo, saves cropped document photo, deletes original
-     * document photo, and returns cropped document photo file path. It repeats that for
-     * all document photos.
-     */
+    /// Crops the documented pages, deletes temporary files, and returns file paths to parent activity.
     private fun cropDocumentAndFinishIntent() {
         val croppedImageResults = arrayListOf<String>()
         android.util.Log.d("DocumentScannerActivity", "cropDocumentAndFinishIntent starting for ${documents.size} documents")
         for ((pageNumber, document) in documents.withIndex()) {
-            // crop document photo by using corners
             val croppedImage: Bitmap? = try {
                 ImageUtil().crop(
                     document.originalPhotoFilePath,
@@ -366,10 +293,8 @@ class DocumentScannerActivity : AppCompatActivity() {
                 return
             }
 
-            // delete original document photo
             File(document.originalPhotoFilePath).delete()
 
-            // save cropped document photo
             try {
                 val croppedImageFile = FileUtil().createImageFile(this, pageNumber)
                 croppedImage.saveToFile(croppedImageFile, croppedImageQuality)
@@ -384,7 +309,6 @@ class DocumentScannerActivity : AppCompatActivity() {
             }
         }
 
-        // return array of cropped document photo file paths
         android.util.Log.d("DocumentScannerActivity", "Finishing success with cropped results: $croppedImageResults")
         setResult(
             Activity.RESULT_OK,
@@ -393,12 +317,7 @@ class DocumentScannerActivity : AppCompatActivity() {
         finish()
     }
 
-    /**
-     * This ends the document scanner activity, and returns an error message that can be
-     * used to debug error
-     *
-     * @param errorMessage an error message
-     */
+    /// Finishes the activity returning an error message in intent extras.
     private fun finishIntentWithError(errorMessage: String) {
         setResult(
             Activity.RESULT_OK,

--- a/android/src/main/kotlin/biz/cunning/cunning_document_scanner/fallback/DocumentScannerFileProvider.kt
+++ b/android/src/main/kotlin/biz/cunning/cunning_document_scanner/fallback/DocumentScannerFileProvider.kt
@@ -2,5 +2,6 @@ package biz.cunning.cunning_document_scanner.fallback
 
 import androidx.core.content.FileProvider
 
+/// Custom FileProvider class to handle secure content:// Uri generation for image files.
 class DocumentScannerFileProvider: FileProvider() {
 }

--- a/android/src/main/kotlin/biz/cunning/cunning_document_scanner/fallback/constants/DefaultSetting.kt
+++ b/android/src/main/kotlin/biz/cunning/cunning_document_scanner/fallback/constants/DefaultSetting.kt
@@ -1,11 +1,12 @@
 package biz.cunning.cunning_document_scanner.fallback.constants
 
-/**
- * This class contains default document scanner options
- */
+/// Holds default fallback configuration parameters.
 class DefaultSetting {
     companion object {
+        /// Default output compression quality (100 is lossless/highest quality).
         const val CROPPED_IMAGE_QUALITY = 100
+        
+        /// Default limit on the maximum number of pages a user can scan.
         const val MAX_NUM_DOCUMENTS = 24
     }
 }

--- a/android/src/main/kotlin/biz/cunning/cunning_document_scanner/fallback/constants/DocumentScannerExtra.kt
+++ b/android/src/main/kotlin/biz/cunning/cunning_document_scanner/fallback/constants/DocumentScannerExtra.kt
@@ -1,11 +1,12 @@
 package biz.cunning.cunning_document_scanner.fallback.constants
 
-/**
- * This class contains constants meant to be used as intent extras
- */
+/// Holds keys for Intent Extras passed to the fallback DocumentScannerActivity.
 class DocumentScannerExtra {
     companion object {
+        /// Intent extra key for cropped image quality integer setting.
         const val EXTRA_CROPPED_IMAGE_QUALITY = "croppedImageQuality"
+        
+        /// Intent extra key for the maximum number of pages allowed.
         const val EXTRA_MAX_NUM_DOCUMENTS = "maxNumDocuments"
     }
 }

--- a/android/src/main/kotlin/biz/cunning/cunning_document_scanner/fallback/enums/QuadCorner.kt
+++ b/android/src/main/kotlin/biz/cunning/cunning_document_scanner/fallback/enums/QuadCorner.kt
@@ -1,8 +1,16 @@
 package biz.cunning.cunning_document_scanner.fallback.enums
 
-/**
- * enums for all 4 quad corners
- */
+/// Enum representing the four corners of a document cropping quad.
 enum class QuadCorner {
-    TOP_LEFT, TOP_RIGHT, BOTTOM_RIGHT, BOTTOM_LEFT
+    /// Top-left corner of the crop quad.
+    TOP_LEFT, 
+    
+    /// Top-right corner of the crop quad.
+    TOP_RIGHT, 
+    
+    /// Bottom-right corner of the crop quad.
+    BOTTOM_RIGHT, 
+    
+    /// Bottom-left corner of the crop quad.
+    BOTTOM_LEFT
 }

--- a/android/src/main/kotlin/biz/cunning/cunning_document_scanner/fallback/models/Document.kt
+++ b/android/src/main/kotlin/biz/cunning/cunning_document_scanner/fallback/models/Document.kt
@@ -1,15 +1,11 @@
 package biz.cunning.cunning_document_scanner.fallback.models
 
-/**
- * This class contains the original document photo, and a cropper. The user can drag the corners
- * to make adjustments to the detected corners.
- *
- * @param originalPhotoFilePath the photo file path before cropping
- * @param originalPhotoWidth the original photo width
- * @param originalPhotoHeight the original photo height
- * @param corners the document's 4 corner points
- * @constructor creates a document
- */
+/// Represents a scanned document, holding the file path, size dimensions, and cropping corner coordinates.
+///
+/// @param originalPhotoFilePath The local file path to the original un-cropped photo.
+/// @param originalPhotoWidth The width of the original photo in pixels.
+/// @param originalPhotoHeight The height of the original photo in pixels.
+/// @param corners The Quad representation of the four crop corner coordinates.
 class Document(
     val originalPhotoFilePath: String,
     private val originalPhotoWidth: Int,

--- a/android/src/main/kotlin/biz/cunning/cunning_document_scanner/fallback/models/Line.kt
+++ b/android/src/main/kotlin/biz/cunning/cunning_document_scanner/fallback/models/Line.kt
@@ -2,14 +2,14 @@ package biz.cunning.cunning_document_scanner.fallback.models
 
 import android.graphics.PointF
 
-/**
- * represents a line connecting 2 Android points
- *
- * @param fromPoint the 1st point
- * @param toPoint the 2nd point
- * @constructor creates a line connecting 2 points
- */
+/// Represents a line segment connecting two points.
+///
+/// @param fromPoint The starting coordinate.
+/// @param toPoint The ending coordinate.
 class Line(fromPoint: PointF, toPoint: PointF) {
+    /// The starting point of the line segment.
     val from: PointF = fromPoint
+    
+    /// The ending point of the line segment.
     val to: PointF = toPoint
 }

--- a/android/src/main/kotlin/biz/cunning/cunning_document_scanner/fallback/models/Point.kt
+++ b/android/src/main/kotlin/biz/cunning/cunning_document_scanner/fallback/models/Point.kt
@@ -1,9 +1,14 @@
 package biz.cunning.cunning_document_scanner.fallback.models
 
-
-//javadoc:Point_
+/// Represents a 2D point coordinate using Double precision values.
+///
+/// @param x The horizontal coordinate value.
+/// @param y The vertical coordinate value.
 class Point @JvmOverloads constructor(x: Double = 0.0, y: Double = 0.0) {
+    /// Horizontal coordinate.
     var x = 0.0
+    
+    /// Vertical coordinate.
     var y = 0.0
 
     init {
@@ -11,6 +16,8 @@ class Point @JvmOverloads constructor(x: Double = 0.0, y: Double = 0.0) {
         this.y = y
     }
 
+    /// Sets the point coordinates from a DoubleArray.
+    /// - vals: DoubleArray containing [x, y] coordinates.
     fun set(vals: DoubleArray?) {
         if (vals != null) {
             x = if (vals.size > 0) vals[0] else 0.0
@@ -20,7 +27,6 @@ class Point @JvmOverloads constructor(x: Double = 0.0, y: Double = 0.0) {
             y = 0.0
         }
     }
-
 
     override fun hashCode(): Int {
         val prime = 31

--- a/android/src/main/kotlin/biz/cunning/cunning_document_scanner/fallback/models/Quad.kt
+++ b/android/src/main/kotlin/biz/cunning/cunning_document_scanner/fallback/models/Quad.kt
@@ -8,24 +8,19 @@ import biz.cunning.cunning_document_scanner.fallback.extensions.move
 import biz.cunning.cunning_document_scanner.fallback.extensions.multiply
 import biz.cunning.cunning_document_scanner.fallback.extensions.toPointF
 
-/**
- * This class is used to represent the cropper. It contains 4 corners.
- *
- * @param topLeftCorner the top left corner
- * @param topRightCorner the top right corner
- * @param bottomRightCorner the bottom right corner
- * @param bottomLeftCorner the bottom left corner
- * @constructor creates a quad from Android points
- */
+/// Represents the four corners defining a cropping quadrilateral.
+///
+/// @param topLeftCorner The top-left corner coordinate.
+/// @param topRightCorner The top-right corner coordinate.
+/// @param bottomRightCorner The bottom-right corner coordinate.
+/// @param bottomLeftCorner The bottom-left corner coordinate.
 class Quad(
     val topLeftCorner: PointF,
     val topRightCorner: PointF,
     val bottomRightCorner: PointF,
     val bottomLeftCorner: PointF
 ) {
-    /**
-     * @constructor creates a quad from OpenCV points
-     */
+    /// Secondary constructor to build a Quad from OpenCV-style Point models.
     constructor(
         topLeftCorner: Point,
         topRightCorner: Point,
@@ -38,9 +33,7 @@ class Quad(
         bottomLeftCorner.toPointF()
     )
 
-    /**
-     * @property corners lets us get the point coordinates for any corner
-     */
+    /// Map associating each QuadCorner enum with its respective coordinate point.
     var corners: MutableMap<QuadCorner, PointF> = mutableMapOf(
         QuadCorner.TOP_LEFT to topLeftCorner,
         QuadCorner.TOP_RIGHT to topRightCorner,
@@ -48,9 +41,7 @@ class Quad(
         QuadCorner.BOTTOM_LEFT to bottomLeftCorner
     )
 
-    /**
-     * @property edges 4 lines that connect the 4 corners
-     */
+    /// The four lines forming the boundary edges of the crop zone quadrilateral.
     val edges: Array<Line> get() = arrayOf(
         Line(topLeftCorner, topRightCorner),
         Line(topRightCorner, bottomRightCorner),
@@ -58,36 +49,20 @@ class Quad(
         Line(bottomLeftCorner, topLeftCorner)
     )
 
-    /**
-     * This finds the corner that's closest to a point. When a user touches to drag
-     * the cropper, that point is used to determine which corner to move.
-     *
-     * @param point we want to find the corner closest to this point
-     * @return the closest corner
-     */
+    /// Returns the QuadCorner closest to the given target coordinate point.
+    /// Used to select which handle to drag during touch actions.
     fun getCornerClosestToPoint(point: PointF): QuadCorner {
         return corners.minByOrNull { corner -> corner.value.distance(point) }?.key!!
     }
 
-    /**
-     * This moves a corner by (dx, dy)
-     *
-     * @param corner the corner that needs to be moved
-     * @param dx the corner moves dx horizontally
-     * @param dy the corner moves dy vertically
-     */
+    /// Displaces the coordinate of the specified corner by a delta offset (dx, dy).
     fun moveCorner(corner: QuadCorner, dx: Float, dy: Float) {
         corners[corner]?.offset(dx, dy)
     }
 
-    /**
-     * This maps original image coordinates to preview image coordinates. The original image
-     * is probably larger than the preview image.
-     *
-     * @param imagePreviewBounds offset the point by the top left of imagePreviewBounds
-     * @param ratio multiply the point by ratio
-     * @return the 4 corners after mapping coordinates
-     */
+    /// Maps absolute source photo coordinates to scaling preview widget bounds.
+    /// - imagePreviewBounds: Display boundaries of the target preview widget.
+    /// - ratio: Image-to-preview scale multiplier factor.
     fun mapOriginalToPreviewImageCoordinates(imagePreviewBounds: RectF, ratio: Float): Quad {
         return Quad(
             topLeftCorner.multiply(ratio).move(
@@ -109,14 +84,9 @@ class Quad(
         )
     }
 
-    /**
-     * This maps preview image coordinates to original image coordinates. The original image
-     * is probably larger than the preview image.
-     *
-     * @param imagePreviewBounds reverse offset the point by the top left of imagePreviewBounds
-     * @param ratio divide the point by ratio
-     * @return the 4 corners after mapping coordinates
-     */
+    /// Maps preview coordinates back to original absolute pixel bounds.
+    /// - imagePreviewBounds: Display boundaries of the preview widget.
+    /// - ratio: Image-to-preview scale multiplier factor.
     fun mapPreviewToOriginalImageCoordinates(imagePreviewBounds: RectF, ratio: Float): Quad {
         return Quad(
             topLeftCorner.move(

--- a/android/src/main/kotlin/biz/cunning/cunning_document_scanner/fallback/ui/CircleButton.kt
+++ b/android/src/main/kotlin/biz/cunning/cunning_document_scanner/fallback/ui/CircleButton.kt
@@ -8,39 +8,26 @@ import android.util.AttributeSet
 import androidx.appcompat.widget.AppCompatImageButton
 import biz.cunning.cunning_document_scanner.R
 
-/**
- * This class creates a circular done button by modifying an image button. This is used for the
- * add new document button and retake photo button.
- *
- * @param context image button context
- * @param attrs image button attributes
- * @constructor creates circle button
- */
+/// Custom circular image button that draws a white border ring.
+/// Used for helper controls like retake and add-new-photo.
 class CircleButton(
     context: Context,
     attrs: AttributeSet
 ): AppCompatImageButton(context, attrs) {
-    /**
-     * @property ring the button's outer ring
-     */
+    
+    /// The paint configuration for the button's outer ring.
     private val ring = Paint(Paint.ANTI_ALIAS_FLAG)
 
     init {
-        // set outer ring style
         ring.color = Color.WHITE
         ring.style = Paint.Style.STROKE
         ring.strokeWidth = resources.getDimension(R.dimen.small_button_ring_thickness)
     }
 
-    /**
-     * This gets called repeatedly. We use it to draw the button
-     *
-     * @param canvas the image button canvas
-     */
+    /// Draws the button and renders the custom circular outer ring border.
     override fun onDraw(canvas: Canvas) {
         super.onDraw(canvas)
 
-        // draw outer ring
         canvas.drawCircle(
             (width / 2).toFloat(),
             (height / 2).toFloat(),

--- a/android/src/main/kotlin/biz/cunning/cunning_document_scanner/fallback/ui/DoneButton.kt
+++ b/android/src/main/kotlin/biz/cunning/cunning_document_scanner/fallback/ui/DoneButton.kt
@@ -10,48 +10,31 @@ import androidx.core.content.ContextCompat
 import biz.cunning.cunning_document_scanner.R
 import biz.cunning.cunning_document_scanner.fallback.extensions.drawCheck
 
-/**
- * This class creates a circular done button by modifying an image button. The user presses
- * this button once they finish cropping an image
- *
- * @param context image button context
- * @param attrs image button attributes
- * @constructor creates done button
- */
+/// Custom Done checkmark button with custom inner circle fill and outer ring border.
 class DoneButton(
     context: Context,
     attrs: AttributeSet
 ): AppCompatImageButton(context, attrs) {
-    /**
-     * @property ring the button's outer ring
-     */
+    
+    /// The paint configuration for the button's outer ring.
     private val ring = Paint(Paint.ANTI_ALIAS_FLAG)
 
-    /**
-     * @property circle the button's inner circle
-     */
+    /// The paint configuration for the button's inner circle.
     private val circle = Paint(Paint.ANTI_ALIAS_FLAG)
 
     init {
-        // set outer ring style
         ring.color = Color.WHITE
         ring.style = Paint.Style.STROKE
         ring.strokeWidth = resources.getDimension(R.dimen.large_button_ring_thickness)
 
-        // set inner circle style
         circle.color = ContextCompat.getColor(context, R.color.done_button_inner_circle_color)
         circle.style = Paint.Style.FILL
     }
 
-    /**
-     * This gets called repeatedly. We use it to draw the done button.
-     *
-     * @param canvas the image button canvas
-     */
+    /// Renders the done button elements including outer ring, inner circle, and the checkmark icon.
     override fun onDraw(canvas: Canvas) {
         super.onDraw(canvas)
 
-        // calculate button center point, outer ring radius, and inner circle radius
         val centerX = width.toFloat() / 2
         val centerY = height.toFloat() / 2
         val outerRadius = (width.toFloat() - ring.strokeWidth) / 2
@@ -59,13 +42,8 @@ class DoneButton(
             R.dimen.large_button_outer_ring_offset
         )
 
-        // draw outer ring
         canvas.drawCircle(centerX, centerY, outerRadius, ring)
-
-        // draw inner circle
         canvas.drawCircle(centerX, centerY, innerRadius, circle)
-
-        // draw check icon since it gets covered by inner circle
         canvas.drawCheck(centerX, centerY, drawable)
     }
 }

--- a/android/src/main/kotlin/biz/cunning/cunning_document_scanner/fallback/ui/ImageCropView.kt
+++ b/android/src/main/kotlin/biz/cunning/cunning_document_scanner/fallback/ui/ImageCropView.kt
@@ -20,104 +20,62 @@ import biz.cunning.cunning_document_scanner.fallback.extensions.changeByteCountB
 import biz.cunning.cunning_document_scanner.fallback.extensions.drawQuad
 import biz.cunning.cunning_document_scanner.fallback.models.Quad
 
-/**
- * This class contains the original document photo, and a cropper. The user can drag the corners
- * to make adjustments to the detected corners.
- *
- * @param context view context
- * @param attrs view attributes
- * @constructor creates image crop view
- */
+/// Custom ImageView displaying the original document photo and an interactive cropping box.
+/// Enables users to drag crop corners to correct skewing manually.
 class ImageCropView(context: Context, attrs: AttributeSet) : AppCompatImageView(context, attrs) {
 
-    /**
-     * @property quad the 4 document corners
-     */
+    /// The quadrilateral object representing the four corners of the cropping window.
     private var quad: Quad? = null
 
-    /**
-     * @property prevTouchPoint keep track of where the user touches, so we know how much
-     * to move corners on drag
-     */
+    /// Tracks the previous touch point coordinate to calculate displacement distances.
     private var prevTouchPoint: PointF? = null
 
-    /**
-     * @property closestCornerToTouch if the user touches close to the top left corner for
-     * example, that corner should move on drag
-     */
+    /// Identifies the corner nearest to the user's touch action being actively dragged.
     private var closestCornerToTouch: QuadCorner? = null
 
-    /**
-     * @property cropperLinesAndCornersStyles paint style for 4 corners and connecting lines
-     */
+    /// Styling paint configuration for the cropping overlay borders and lines.
     private val cropperLinesAndCornersStyles = Paint(Paint.ANTI_ALIAS_FLAG)
 
-    /**
-     * @property cropperSelectedCornerFillStyles when you tap and drag a cropper corner the circle
-     * acts like a magnifying glass
-     */
+    /// Shader fill configurations used to draw a magnified lens over the active corner during drags.
     private val cropperSelectedCornerFillStyles = Paint()
 
-    /**
-     * @property imagePreviewHeight this is needed because height doesn't update immediately
-     * after we set the image
-     */
+    /// Internal cached height of the image preview container.
     private var imagePreviewHeight = height
 
-    /**
-     * @property imagePreviewWidth this is needed because width doesn't update immediately
-     * after we set the image
-     */
+    /// Internal cached width of the image preview container.
     private var imagePreviewWidth = width
 
-    /**
-     * @property ratio image container height to image height ratio used to map container
-     * to image coordinates and vice versa
-     */
+    /// Ratio representing the height ratio of the preview widget relative to the intrinsic drawable height.
     private val ratio: Float get() = imagePreviewBounds.height() / drawable.intrinsicHeight
 
-    /**
-     * @property corners document corners in image preview coordinates
-     */
+    /// Public getter returning current corner points in preview coordinate terms.
     val corners: Quad get() = quad!!
 
-    /**
-     * @property imagePreviewMaxSizeInBytes if the photo is too big, we need to scale it down
-     * before we display it
-     */
+    /// Maximum memory size limit in bytes before scaling down high-resolution image previews.
     private val imagePreviewMaxSizeInBytes = 100 * 1024 * 1024
 
     init {
-        // set cropper style
         cropperLinesAndCornersStyles.color = Color.WHITE
         cropperLinesAndCornersStyles.style = Paint.Style.STROKE
         cropperLinesAndCornersStyles.strokeWidth = 3f
     }
 
-    /**
-     * Initially the image preview height is 0. This calculates the height by using the photo
-     * dimensions. It maintains the photo aspect ratio (we likely need to scale the photo down
-     * to fit the preview container).
-     *
-     * @param photo the original photo with a rectangular document
-     * @param screenWidth the device width
-     */
+    /// Computes and updates layout bounds for the image preview window to maintain original aspect ratio.
+    /// - photo: The target original bitmap to render.
+    /// - screenWidth: Host device screen width parameter.
+    /// - screenHeight: Host device screen height parameter.
     fun setImagePreviewBounds(photo: Bitmap, screenWidth: Int, screenHeight: Int) {
-        // image width to height aspect ratio
         val imageRatio = photo.width.toFloat() / photo.height.toFloat()
         val buttonsViewMinHeight = context.resources.getDimension(
             R.dimen.buttons_container_min_height
         ).toInt()
 
         imagePreviewHeight = if (photo.height > photo.width) {
-            // if user takes the photo in portrait
             (screenWidth.toFloat() / imageRatio).toInt()
         } else {
-            // if user takes the photo in landscape
             (screenWidth.toFloat() * imageRatio).toInt()
         }
 
-        // set a cap on imagePreviewHeight, so that the bottom buttons container isn't hidden
         imagePreviewHeight = Integer.min(
             imagePreviewHeight,
             screenHeight - buttonsViewMinHeight
@@ -125,20 +83,15 @@ class ImageCropView(context: Context, attrs: AttributeSet) : AppCompatImageView(
 
         imagePreviewWidth = screenWidth
 
-        // image container initially has a 0 width and 0 height, calculate both and set them
         layoutParams.height = imagePreviewHeight
         layoutParams.width = imagePreviewWidth
 
-        // refresh layout after we change height
         requestLayout()
     }
 
-    /**
-     * Insert bitmap in image view, and trigger onSetImage event handler
-     */
+    /// Downscales the source image if needed to save RAM, sets it as the drawable, and updates the shader canvas.
     fun setImage(photo: Bitmap) {
         var previewImagePhoto = photo
-        // if the image is too large, we need to scale it down before displaying it
         if (photo.byteCount > imagePreviewMaxSizeInBytes) {
             previewImagePhoto = photo.changeByteCountByResizing(imagePreviewMaxSizeInBytes)
         }
@@ -146,26 +99,15 @@ class ImageCropView(context: Context, attrs: AttributeSet) : AppCompatImageView(
         this.onSetImage()
     }
 
-    /**
-     * Once the user takes a photo, we try to detect corners. This function stores them as quad.
-     *
-     * @param cropperCorners 4 corner points in original photo coordinates
-     */
+    /// Sets the current cropping corner points within this view.
     fun setCropper(cropperCorners: Quad) {
         quad = cropperCorners
     }
 
-    /**
-     * @property imagePreviewBounds image coordinates - if the image ratio is different than
-     * the image container ratio then there's blank space either at the top and bottom of the
-     * image or the left and right of the image
-     */
+    /// RectF boundaries defining the actual rendered image inside the Aspect-Fit crop container.
     val imagePreviewBounds: RectF
         get() {
-            // image container width to height ratio
             val imageViewRatio: Float = imagePreviewWidth.toFloat() / imagePreviewHeight.toFloat()
-
-            // image width to height ratio
             val imageRatio = drawable.intrinsicWidth.toFloat() / drawable.intrinsicHeight.toFloat()
 
             var left = 0f
@@ -174,14 +116,10 @@ class ImageCropView(context: Context, attrs: AttributeSet) : AppCompatImageView(
             var bottom = imagePreviewHeight.toFloat()
 
             if (imageRatio > imageViewRatio) {
-                // if the image is really wide, there's blank space at the top and bottom
                 val offset = (imagePreviewHeight - (imagePreviewWidth / imageRatio)) / 2
                 top += offset
                 bottom -= offset
             } else {
-                // if the image is really tall, there's blank space at the left and right
-                // it's also possible that the image ratio matches the image container ratio
-                // in which case there's no blank space
                 val offset = (imagePreviewWidth - (imagePreviewHeight * imageRatio)) / 2
                 left += offset
                 right -= offset
@@ -190,12 +128,7 @@ class ImageCropView(context: Context, attrs: AttributeSet) : AppCompatImageView(
             return RectF(left, top, right, bottom)
         }
 
-    /**
-     * This ensures that the user doesn't drag a corner outside the image
-     *
-     * @param point a point
-     * @return true if the point is inside the image preview container, false it's not
-     */
+    /// Verifies if a given coordinate point lies inside the valid visible preview image boundaries.
     private fun isPointInsideImage(point: PointF): Boolean {
         if (point.x >= imagePreviewBounds.left
             && point.y >= imagePreviewBounds.top
@@ -207,9 +140,7 @@ class ImageCropView(context: Context, attrs: AttributeSet) : AppCompatImageView(
         return false
     }
 
-    /**
-     * This gets called once we insert an image in this image view
-     */
+    /// Initializes a BitmapShader with the active preview drawable content to run magnifier zooms.
     private fun onSetImage() {
         cropperSelectedCornerFillStyles.style = Paint.Style.FILL
         cropperSelectedCornerFillStyles.shader = BitmapShader(
@@ -219,16 +150,11 @@ class ImageCropView(context: Context, attrs: AttributeSet) : AppCompatImageView(
         )
     }
 
-    /**
-     * This gets called constantly, and we use it to update the cropper corners
-     *
-     * @param canvas the image preview canvas
-     */
+    /// Redraws the crop quad polygon, corner circles, and the magnifying glass overlay.
     override fun onDraw(canvas: Canvas) {
         super.onDraw(canvas)
 
         if (quad !== null) {
-            // draw 4 corners and connecting lines
             canvas.drawQuad(
                 quad!!,
                 resources.getDimension(R.dimen.cropper_corner_radius),
@@ -241,34 +167,23 @@ class ImageCropView(context: Context, attrs: AttributeSet) : AppCompatImageView(
                 resources.getDimension(R.dimen.cropper_selected_corner_background_magnification)
             )
         }
-
     }
 
-    /**
-     * This gets called when the user touches, drags, and stops touching screen. We use this
-     * to figure out which corner we need to move, and how far we need to move it.
-     *
-     * @param event the touch event
-     */
+    /// Processes MotionEvents to locate, drag, and release corner handles.
     @SuppressLint("ClickableViewAccessibility")
     override fun onTouchEvent(event: MotionEvent): Boolean {
-        // keep track of the touched point
         val touchPoint = PointF(event.x, event.y)
 
         when (event.action) {
             MotionEvent.ACTION_DOWN -> {
-                // when the user touches the screen record the point, and find the closest
-                // corner to the touch point
                 prevTouchPoint = touchPoint
                 closestCornerToTouch = quad!!.getCornerClosestToPoint(touchPoint)
             }
             MotionEvent.ACTION_UP -> {
-                // when the user stops touching the screen reset these values
                 prevTouchPoint = null
                 closestCornerToTouch = null
             }
             MotionEvent.ACTION_MOVE -> {
-                // when the user drags their finger, update the closest corner position
                 val touchMoveXDistance = touchPoint.x - prevTouchPoint!!.x
                 val touchMoveYDistance = touchPoint.y - prevTouchPoint!!.y
                 val cornerNewPosition = PointF(
@@ -276,20 +191,15 @@ class ImageCropView(context: Context, attrs: AttributeSet) : AppCompatImageView(
                     quad!!.corners[closestCornerToTouch]!!.y + touchMoveYDistance
                 )
 
-                // make sure the user doesn't drag the corner outside the image preview container
                 if (isPointInsideImage(cornerNewPosition)) {
                     quad!!.moveCorner(closestCornerToTouch!!, touchMoveXDistance, touchMoveYDistance)
                 }
 
-                // record the point touched, so we can use it to calculate how far to move corner
-                // next time the user drags (assuming they don't stop touching the screen)
                 prevTouchPoint = touchPoint
             }
         }
 
-        // force refresh view
         invalidate()
-
         return true
     }
 }

--- a/android/src/main/kotlin/biz/cunning/cunning_document_scanner/fallback/utils/CameraUtil.kt
+++ b/android/src/main/kotlin/biz/cunning/cunning_document_scanner/fallback/utils/CameraUtil.kt
@@ -11,60 +11,45 @@ import androidx.core.content.FileProvider
 import java.io.File
 import java.io.IOException
 
-/**
- * This class contains a helper function for opening the camera.
- *
- * @param activity current activity
- * @param onPhotoCaptureSuccess gets called with photo file path when photo is ready
- * @param onCancelPhoto gets called when user cancels out of camera
- * @constructor creates camera util
- */
+/// Helper utility class to launch the device's system camera, handle photo capture output files,
+/// and notify completion/cancel event callbacks.
+///
+/// @param activity The host ComponentActivity context.
+/// @param onPhotoCaptureSuccess Callback triggered with absolute image path on successful capture.
+/// @param onCancelPhoto Callback triggered when the user aborts/cancels image capture.
 class CameraUtil(
     private val activity: ComponentActivity,
     private val onPhotoCaptureSuccess: (photoFilePath: String) -> Unit,
     private val onCancelPhoto: () -> Unit
 ) {
-    /**
-     * @property photoFilePath the photo file path
-     */
+    /// Holds the file path target for the captured photo.
     private lateinit var photoFilePath: String
 
-    /**
-     * @property startForResult used to launch camera
-     */
+    /// ActivityResultLauncher callback handling camera capture intent results.
     private val startForResult = activity.registerForActivityResult(
         ActivityResultContracts.StartActivityForResult()
     ) { result: ActivityResult ->
         when (result.resultCode) {
             Activity.RESULT_OK -> {
-                // send back photo file path on capture success
                 onPhotoCaptureSuccess(photoFilePath)
             }
             Activity.RESULT_CANCELED -> {
-                // delete the photo since the user didn't finish taking the photo
                 File(photoFilePath).delete()
                 onCancelPhoto()
             }
         }
     }
 
-    /**
-     * open the camera by launching an image capture intent
-     *
-     * @param pageNumber the current document page number
-     */
+    /// Launches an image capture intent and maps output to a temporary image file.
+    /// - pageNumber: The current page index of the document.
     @Throws(IOException::class)
     fun openCamera(pageNumber: Int) {
-        // create intent to launch camera
         val takePictureIntent = Intent(MediaStore.ACTION_IMAGE_CAPTURE)
 
-        // create new file for photo
         val photoFile: File = FileUtil().createImageFile(activity, pageNumber)
 
-        // store the photo file path, and send it back once the photo is saved
         photoFilePath = photoFile.absolutePath
 
-        // photo gets saved to this file path
         val photoURI: Uri = FileProvider.getUriForFile(
             activity,
             "${activity.packageName}.DocumentScannerFileProvider",
@@ -72,7 +57,6 @@ class CameraUtil(
         )
         takePictureIntent.putExtra(MediaStore.EXTRA_OUTPUT, photoURI)
 
-        // open camera
         startForResult.launch(takePictureIntent)
     }
 }

--- a/android/src/main/kotlin/biz/cunning/cunning_document_scanner/fallback/utils/FileUtil.kt
+++ b/android/src/main/kotlin/biz/cunning/cunning_document_scanner/fallback/utils/FileUtil.kt
@@ -11,27 +11,19 @@ import java.text.SimpleDateFormat
 import java.util.Locale
 import java.util.Date
 
-/**
- * This class contains a helper function creating temporary files
- *
- * @constructor creates file util
- */
+/// Helper utility class to manage local file system resources, temporary files creation, and PDF compiling.
 class FileUtil {
-    /**
-     * create a temporary file
-     *
-     * @param activity the current activity
-     * @param pageNumber the current document page number
-     */
+    
+    /// Generates a unique temporary image file under the application's pictures directory.
+    /// - activity: The current active host Activity.
+    /// - pageNumber: The document page number used to prefix the filename.
     @Throws(IOException::class)
     fun createImageFile(activity: Activity, pageNumber: Int): File {
-        // use current time to make file name more unique
         val dateTime: String = SimpleDateFormat(
             "yyyyMMdd_HHmmss",
             Locale.US
         ).format(Date())
 
-        // create file in pictures directory
         val storageDir: File? = activity.getExternalFilesDir(Environment.DIRECTORY_PICTURES)
         return File.createTempFile(
             "DOCUMENT_SCAN_${pageNumber}_${dateTime}",
@@ -40,11 +32,8 @@ class FileUtil {
         )
     }
 
-    /**
-     * create a temporary PDF file
-     *
-     * @param activity the current activity
-     */
+    /// Generates a unique temporary PDF file target under the application's pictures directory.
+    /// - activity: The current active host Activity.
     @Throws(IOException::class)
     fun createPdfFile(activity: Activity): File {
         val dateTime: String = SimpleDateFormat(
@@ -60,12 +49,9 @@ class FileUtil {
         )
     }
 
-    /**
-     * convert a list of image file paths to a single PDF file
-     *
-     * @param imagePaths the list of paths to images
-     * @param pdfFile the output PDF file
-     */
+    /// Compiles a list of image paths into a single output PDF document.
+    /// - imagePaths: List of absolute image paths.
+    /// - pdfFile: The output file where the PDF will be written.
     @Throws(IOException::class)
     fun convertImagesToPdf(imagePaths: List<String>, pdfFile: File) {
         val pdfDocument = PdfDocument()

--- a/android/src/main/kotlin/biz/cunning/cunning_document_scanner/fallback/utils/ImageUtil.kt
+++ b/android/src/main/kotlin/biz/cunning/cunning_document_scanner/fallback/utils/ImageUtil.kt
@@ -12,9 +12,11 @@ import biz.cunning.cunning_document_scanner.fallback.models.Quad
 import kotlin.math.pow
 import kotlin.math.sqrt
 
-
+/// Helper utility class to decode, rotate, perspective-correct, and crop document images.
 class ImageUtil {
 
+    /// Loads and returns a bitmap from the specified file path, correcting rotation orientation metadata.
+    /// - filePath: The absolute file path to the source image.
     fun getImageFromFilePath(filePath: String): Bitmap? {
         val rotation = getRotationDegrees(filePath)
         val bitmap = BitmapFactory.decodeFile(filePath) ?: return null
@@ -27,6 +29,7 @@ class ImageUtil {
         }
     }
 
+    /// Resolves rotation degree properties by parsing ExifInterface headers.
     private fun getRotationDegrees(filePath: String): Int {
         val exif = ExifInterface(filePath)
         return when (exif.getAttributeInt(
@@ -40,11 +43,12 @@ class ImageUtil {
         }
     }
 
-
+    /// Crops the target photo by applying a perspective correction transformation using corner coordinates.
+    /// - photoFilePath: The file path to the source image.
+    /// - corners: Quad object representing selection corners.
     fun crop(photoFilePath: String, corners: Quad): Bitmap? {
         val bitmap = getImageFromFilePath(photoFilePath) ?: return null
 
-        // Convert Quad corners to a float array manually
         val src = floatArrayOf(
             corners.topLeftCorner.x, corners.topLeftCorner.y,
             corners.topRightCorner.x, corners.topRightCorner.y,
@@ -55,7 +59,6 @@ class ImageUtil {
         val avgWidth = getAvgWidth(corners)
         val avgHeight = getAvgHeight(corners)
 
-        // Maintain the aspect ratio based on the longer dimension
         val aspectRatio = avgWidth / avgHeight
 
         val dstWidth: Float
@@ -69,7 +72,6 @@ class ImageUtil {
             dstWidth = dstHeight * aspectRatio
         }
 
-        // Use dstWidth and dstHeight to define your dst points accordingly
         val dst = floatArrayOf(
             0f, 0f,                     // Top-left
             dstWidth, 0f,               // Top-right
@@ -80,6 +82,12 @@ class ImageUtil {
         return correctPerspective(bitmap, src, dst, dstWidth, dstHeight)
     }
 
+    /// Performs poly-to-poly matrix transform mapping to stretch/de-skew perspective quad bounds.
+    /// - b: The source bitmap.
+    /// - srcPoints: Source corner points float coordinates.
+    /// - dstPoints: Destination bounding coordinates.
+    /// - w: Output width.
+    /// - h: Output height.
     fun correctPerspective(b: Bitmap, srcPoints: FloatArray?, dstPoints: FloatArray?, w: Float, h: Float): Bitmap {
         val result = Bitmap.createBitmap(w.toInt(), h.toInt(), Bitmap.Config.ARGB_8888)
         val p = Paint(Paint.ANTI_ALIAS_FLAG)
@@ -90,6 +98,7 @@ class ImageUtil {
         return result
     }
 
+    /// Calculates the average width between top and bottom edges.
     private fun getAvgWidth(corners: Quad): Float {
         val widthTop = sqrt(
             (corners.topRightCorner.x - corners.topLeftCorner.x).toDouble().pow(2.0) + (corners.topRightCorner.y - corners.topLeftCorner.y).toDouble()
@@ -102,6 +111,7 @@ class ImageUtil {
         return (widthTop + widthBottom) / 2
     }
 
+    /// Calculates the average height between left and right edges.
     private fun getAvgHeight(corners: Quad): Float {
         val heightLeft = sqrt(
             (corners.bottomLeftCorner.x - corners.topLeftCorner.x).toDouble().pow(2.0) + (corners.bottomLeftCorner.y - corners.topLeftCorner.y).toDouble()

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -71,7 +71,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.6.0"
+    version: "2.7.0"
   cupertino_icons:
     dependency: "direct main"
     description:

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/CroppingOverlayView.swift
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/CroppingOverlayView.swift
@@ -1,0 +1,209 @@
+import UIKit
+
+/// A overlay canvas overlaying the image view that draws the perspective crop bounding box
+/// and exposes four corner handles that the user can drag to define crop coordinates.
+class CroppingOverlayView: UIView {
+    
+    /// The coordinates of the top-left cropping handle in the local coordinate space.
+    var topLeft = CGPoint.zero
+    
+    /// The coordinates of the top-right cropping handle in the local coordinate space.
+    var topRight = CGPoint.zero
+    
+    /// The coordinates of the bottom-left cropping handle in the local coordinate space.
+    var bottomLeft = CGPoint.zero
+    
+    /// The coordinates of the bottom-right cropping handle in the local coordinate space.
+    var bottomRight = CGPoint.zero
+    
+    /// The calculated bounding frame of the aspect-fit image content within the parent UIImageView.
+    var contentFrame = CGRect.zero
+    
+    /// A callback closure invoked whenever any corner handle coordinates are updated by the user.
+    var onPointsChanged: (() -> Void)?
+    
+    /// The views representing the four circular corner touch targets.
+    private var handles: [UIView] = []
+    
+    /// The size/diameter of the corner touch handles.
+    private let handleSize: CGFloat = 34
+    
+    /// The current magnifier lens overlay, visible during active handle dragging.
+    private var magnifierView: MagnifierView?
+    
+    /// The specific handle view currently being dragged by the user, if any.
+    /// Used to enforce single-touch drag constraints and prevent multi-touch conflicts.
+    private var activeHandle: UIView?
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        backgroundColor = .clear
+        setupHandles()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        backgroundColor = .clear
+        setupHandles()
+    }
+    
+    /// Populates and configures the four corner handle subviews with UIPanGestureRecognizers.
+    private func setupHandles() {
+        for i in 0..<4 {
+            let handle = UIView(frame: CGRect(x: 0, y: 0, width: handleSize, height: handleSize))
+            handle.backgroundColor = UIColor.systemBlue.withAlphaComponent(0.8)
+            handle.layer.cornerRadius = handleSize / 2
+            handle.layer.borderWidth = 3
+            handle.layer.borderColor = UIColor.white.cgColor
+            handle.tag = i
+            
+            let pan = UIPanGestureRecognizer(target: self, action: #selector(handlePan(_:)))
+            handle.addGestureRecognizer(pan)
+            addSubview(handle)
+            handles.append(handle)
+        }
+    }
+    
+    /// Updates the visual positions of the corner handles to reflect current coordinate properties.
+    func updateHandlePositions() {
+        guard handles.count == 4 else { return }
+        handles[0].center = topLeft
+        handles[1].center = topRight
+        handles[2].center = bottomLeft
+        handles[3].center = bottomRight
+        setNeedsDisplay()
+    }
+    
+    /// Processes UIPanGestureRecognizer drag events to move handles, notify coordinates change,
+    /// and present/update the MagnifierView zoom lens.
+    @objc private func handlePan(_ gesture: UIPanGestureRecognizer) {
+        guard let handle = gesture.view else { return }
+        
+        if let active = activeHandle, active !== handle {
+            return
+        }
+        
+        let translation = gesture.translation(in: self)
+        var newCenter = CGPoint(x: handle.center.x + translation.x, y: handle.center.y + translation.y)
+        
+        // Restrict drag inside the image content frame (if set)
+        if contentFrame != .zero {
+            newCenter.x = max(contentFrame.minX, min(contentFrame.maxX, newCenter.x))
+            newCenter.y = max(contentFrame.minY, min(contentFrame.maxY, newCenter.y))
+        } else {
+            newCenter.x = max(0, min(bounds.width, newCenter.x))
+            newCenter.y = max(0, min(bounds.height, newCenter.y))
+        }
+        
+        handle.center = newCenter
+        gesture.setTranslation(.zero, in: self)
+        
+        switch handle.tag {
+        case 0: topLeft = newCenter
+        case 1: topRight = newCenter
+        case 2: bottomLeft = newCenter
+        case 3: bottomRight = newCenter
+        default: break
+        }
+        
+        onPointsChanged?()
+        setNeedsDisplay()
+        
+        // Magnifier View updates
+        let touchPointInSelf = newCenter
+        guard let parentView = self.superview else { return }
+        let touchPointInParent = self.convert(touchPointInSelf, to: parentView)
+        
+        switch gesture.state {
+        case .began:
+            activeHandle = handle
+            let magnifier = MagnifierView(frame: CGRect(x: 0, y: 0, width: 90, height: 90))
+            
+            // Temporarily hide the overlay view so it isn't captured in the zoom lens background
+            self.isHidden = true
+            
+            // Snapshot the parent view once
+            let renderer = UIGraphicsImageRenderer(size: parentView.bounds.size)
+            let snapshot = renderer.image { ctx in
+                parentView.layer.render(in: ctx.cgContext)
+            }
+            
+            // Restore visibility
+            self.isHidden = false
+            
+            magnifier.snapshotImage = snapshot
+            parentView.addSubview(magnifier)
+            self.magnifierView = magnifier
+            updateMagnifier(touchPoint: touchPointInParent, touchPointInSelf: touchPointInParent)
+        case .changed:
+            updateMagnifier(touchPoint: touchPointInParent, touchPointInSelf: touchPointInParent)
+        case .ended, .cancelled:
+            magnifierView?.removeFromSuperview()
+            magnifierView = nil
+            activeHandle = nil
+        default:
+            break
+        }
+    }
+    
+    /// Positions and offsets the magnifier view above or below the user's touch coordinate.
+    private func updateMagnifier(touchPoint: CGPoint, touchPointInSelf: CGPoint) {
+        guard let magnifier = magnifierView, let parentView = self.superview else { return }
+        magnifier.touchPoint = touchPointInSelf
+        
+        let halfHeight = magnifier.bounds.height / 2
+        
+        // Position the magnifier offset above the touch point.
+        // If the touch point is too close to the top, position it below the touch point to avoid going off-screen or being covered by the finger.
+        let isNearTop = (touchPoint.y - 75) < halfHeight
+        let yOffset: CGFloat = isNearTop ? 75 : -75
+        var magnifierCenter = CGPoint(x: touchPoint.x, y: touchPoint.y + yOffset)
+        
+        // Keep the magnifier within the parent view bounds
+        let halfWidth = magnifier.bounds.width / 2
+        
+        magnifierCenter.x = max(halfWidth, min(parentView.bounds.width - halfWidth, magnifierCenter.x))
+        magnifierCenter.y = max(halfHeight, min(parentView.bounds.height - halfHeight, magnifierCenter.y))
+        
+        magnifier.center = magnifierCenter
+    }
+    
+    /// Renders the quad boundary lines and semi-transparent blue filling representing the crop zone.
+    override func draw(_ rect: CGRect) {
+        guard topLeft != .zero || topRight != .zero || bottomLeft != .zero || bottomRight != .zero else {
+            return
+        }
+        
+        let path = UIBezierPath()
+        path.move(to: topLeft)
+        path.addLine(to: topRight)
+        path.addLine(to: bottomRight)
+        path.addLine(to: bottomLeft)
+        path.close()
+        
+        // Draw fill area
+        UIColor.systemBlue.withAlphaComponent(0.25).setFill()
+        path.fill()
+        
+        // Draw crop frame lines
+        UIColor.systemBlue.setStroke()
+        path.lineWidth = 3
+        path.stroke()
+    }
+    
+    /// Converts a normalized coordinate (0.0 - 1.0, origin bottom-left) to the local view coordinate system.
+    func viewPoint(fromNormalized point: CGPoint, contentFrame: CGRect) -> CGPoint {
+        guard contentFrame.width > 0 && contentFrame.height > 0 else { return .zero }
+        let vx = contentFrame.origin.x + point.x * contentFrame.size.width
+        let vy = contentFrame.origin.y + (1.0 - point.y) * contentFrame.size.height
+        return CGPoint(x: vx, y: vy)
+    }
+    
+    /// Converts a local view coordinate to a normalized coordinate (0.0 - 1.0, origin bottom-left).
+    func normalizedPoint(fromView point: CGPoint, contentFrame: CGRect) -> CGPoint {
+        guard contentFrame.width > 0 && contentFrame.height > 0 else { return .zero }
+        let px = (point.x - contentFrame.origin.x) / contentFrame.size.width
+        let py = 1.0 - (point.y - contentFrame.origin.y) / contentFrame.size.height
+        return CGPoint(x: max(0.0, min(1.0, px)), y: max(0.0, min(1.0, py)))
+    }
+}

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/CunningDocumentCropperViewController.swift
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/CunningDocumentCropperViewController.swift
@@ -506,13 +506,15 @@ class CunningDocumentCropperViewController: UIViewController {
         guard let rawCIImage = CIImage(image: image) else { return nil }
         let ciImage = rawCIImage.oriented(CGImagePropertyOrientation(image.imageOrientation))
         
+        let originX = ciImage.extent.origin.x
+        let originY = ciImage.extent.origin.y
         let w = ciImage.extent.width
         let h = ciImage.extent.height
         
-        let tl = CIVector(x: topLeft.x * w, y: topLeft.y * h)
-        let tr = CIVector(x: topRight.x * w, y: topRight.y * h)
-        let bl = CIVector(x: bottomLeft.x * w, y: bottomLeft.y * h)
-        let br = CIVector(x: bottomRight.x * w, y: bottomRight.y * h)
+        let tl = CIVector(x: originX + topLeft.x * w, y: originY + topLeft.y * h)
+        let tr = CIVector(x: originX + topRight.x * w, y: originY + topRight.y * h)
+        let bl = CIVector(x: originX + bottomLeft.x * w, y: originY + bottomLeft.y * h)
+        let br = CIVector(x: originX + bottomRight.x * w, y: originY + bottomRight.y * h)
         
         guard let filter = CIFilter(name: "CIPerspectiveCorrection") else { return nil }
         filter.setValue(ciImage, forKey: kCIInputImageKey)
@@ -648,12 +650,16 @@ class CroppingOverlayView: UIView {
         guard let magnifier = magnifierView, let parentView = self.superview else { return }
         magnifier.touchPoint = touchPointInSelf
         
-        // Position the magnifier offset above the touch point
-        var magnifierCenter = CGPoint(x: touchPoint.x, y: touchPoint.y - 75)
+        let halfHeight = magnifier.bounds.height / 2
+        
+        // Position the magnifier offset above the touch point.
+        // If the touch point is too close to the top, position it below the touch point to avoid going off-screen or being covered by the finger.
+        let isNearTop = (touchPoint.y - 75) < halfHeight
+        let yOffset: CGFloat = isNearTop ? 75 : -75
+        var magnifierCenter = CGPoint(x: touchPoint.x, y: touchPoint.y + yOffset)
         
         // Keep the magnifier within the parent view bounds
         let halfWidth = magnifier.bounds.width / 2
-        let halfHeight = magnifier.bounds.height / 2
         
         magnifierCenter.x = max(halfWidth, min(parentView.bounds.width - halfWidth, magnifierCenter.x))
         magnifierCenter.y = max(halfHeight, min(parentView.bounds.height - halfHeight, magnifierCenter.y))
@@ -705,15 +711,15 @@ extension UIImage {
     func fixedOrientation() -> UIImage {
         if imageOrientation == .up { return self }
         
-        let renderer = UIGraphicsImageRenderer(size: size)
+        let format = UIGraphicsImageRendererFormat.default()
+        format.scale = self.scale
+        let renderer = UIGraphicsImageRenderer(size: size, format: format)
         return renderer.image { _ in
             self.draw(in: CGRect(origin: .zero, size: size))
         }
     }
     
     func rotated90Clockwise() -> UIImage? {
-        guard let cgImage = self.cgImage else { return nil }
-        
         let newOrientation: UIImage.Orientation
         switch self.imageOrientation {
         case .up: newOrientation = .right
@@ -727,7 +733,12 @@ extension UIImage {
         @unknown default: newOrientation = .right
         }
         
-        return UIImage(cgImage: cgImage, scale: self.scale, orientation: newOrientation)
+        if let cgImage = self.cgImage {
+            return UIImage(cgImage: cgImage, scale: self.scale, orientation: newOrientation)
+        } else if let ciImage = self.ciImage {
+            return UIImage(ciImage: ciImage, scale: self.scale, orientation: newOrientation)
+        }
+        return nil
     }
     
     func downscaled(toMaxDimension maxDimension: CGFloat) -> UIImage {

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/CunningDocumentCropperViewController.swift
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/CunningDocumentCropperViewController.swift
@@ -503,7 +503,8 @@ class CunningDocumentCropperViewController: UIViewController {
     }
     
     private func cropImage(image: UIImage, topLeft: CGPoint, topRight: CGPoint, bottomLeft: CGPoint, bottomRight: CGPoint) -> UIImage? {
-        guard let ciImage = CIImage(image: image) else { return nil }
+        guard let rawCIImage = CIImage(image: image) else { return nil }
+        let ciImage = rawCIImage.oriented(CGImagePropertyOrientation(image.imageOrientation))
         
         let w = ciImage.extent.width
         let h = ciImage.extent.height
@@ -802,5 +803,23 @@ class MagnifierView: UIView {
         crosshair.addLine(to: CGPoint(x: midX, y: midY + 8))
         crosshair.lineWidth = 1.5
         crosshair.stroke()
+    }
+}
+
+// MARK: - CGImagePropertyOrientation Mapping Helper
+
+extension CGImagePropertyOrientation {
+    init(_ uiOrientation: UIImage.Orientation) {
+        switch uiOrientation {
+        case .up: self = .up
+        case .upMirrored: self = .upMirrored
+        case .down: self = .down
+        case .downMirrored: self = .downMirrored
+        case .leftMirrored: self = .leftMirrored
+        case .right: self = .right
+        case .rightMirrored: self = .rightMirrored
+        case .left: self = .left
+        @unknown default: self = .up
+        }
     }
 }

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/CunningDocumentCropperViewController.swift
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/CunningDocumentCropperViewController.swift
@@ -427,6 +427,18 @@ class CunningDocumentCropperViewController: UIViewController {
                 )
             }
             
+            let finalImage: UIImage
+            if let cropped = cropped {
+                finalImage = cropped
+            } else {
+                // Fallback to original image with orientation fixed/baked in
+                var fixed: UIImage?
+                autoreleasepool {
+                    fixed = currentImage.fixedOrientation()
+                }
+                finalImage = fixed ?? currentImage
+            }
+            
             DispatchQueue.main.async {
                 self.cancelButton.isEnabled = true
                 self.doneButton.isEnabled = true
@@ -434,12 +446,7 @@ class CunningDocumentCropperViewController: UIViewController {
                 self.backButton.isEnabled = true
                 self.activityIndicator.stopAnimating()
                 
-                if let cropped = cropped {
-                    self.croppedImages.append(cropped)
-                } else {
-                    // Fallback to original image if cropping failed
-                    self.croppedImages.append(currentImage)
-                }
+                self.croppedImages.append(finalImage)
                 
                 self.currentIndex += 1
                 if self.currentIndex < self.images.count {
@@ -545,6 +552,7 @@ class CroppingOverlayView: UIView {
     private var handles: [UIView] = []
     private let handleSize: CGFloat = 34
     private var magnifierView: MagnifierView?
+    private var activeHandle: UIView?
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -585,6 +593,11 @@ class CroppingOverlayView: UIView {
     
     @objc private func handlePan(_ gesture: UIPanGestureRecognizer) {
         guard let handle = gesture.view else { return }
+        
+        if let active = activeHandle, active !== handle {
+            return
+        }
+        
         let translation = gesture.translation(in: self)
         var newCenter = CGPoint(x: handle.center.x + translation.x, y: handle.center.y + translation.y)
         
@@ -618,6 +631,7 @@ class CroppingOverlayView: UIView {
         
         switch gesture.state {
         case .began:
+            activeHandle = handle
             let magnifier = MagnifierView(frame: CGRect(x: 0, y: 0, width: 90, height: 90))
             
             // Temporarily hide the overlay view so it isn't captured in the zoom lens background
@@ -641,6 +655,7 @@ class CroppingOverlayView: UIView {
         case .ended, .cancelled:
             magnifierView?.removeFromSuperview()
             magnifierView = nil
+            activeHandle = nil
         default:
             break
         }

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/CunningDocumentCropperViewController.swift
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/CunningDocumentCropperViewController.swift
@@ -123,8 +123,8 @@ class CunningDocumentCropperViewController: UIViewController {
         let config = UIImage.SymbolConfiguration(pointSize: 18, weight: .medium)
         
         cancelButton.setImage(UIImage(systemName: "xmark", withConfiguration: config), for: .normal)
-        cancelButton.tintColor = .black
-        cancelButton.backgroundColor = .white
+        cancelButton.tintColor = .white
+        cancelButton.backgroundColor = UIColor.white.withAlphaComponent(0.15)
         cancelButton.layer.cornerRadius = 22
         cancelButton.clipsToBounds = true
         cancelButton.addTarget(self, action: #selector(handleCancel), for: .touchUpInside)
@@ -147,7 +147,7 @@ class CunningDocumentCropperViewController: UIViewController {
         backButton.setImage(UIImage(systemName: "chevron.left", withConfiguration: config), for: .normal)
         backButton.tintColor = .white
         backButton.backgroundColor = UIColor.white.withAlphaComponent(0.15)
-        backButton.layer.cornerRadius = 18
+        backButton.layer.cornerRadius = 22
         backButton.clipsToBounds = true
         backButton.addTarget(self, action: #selector(handleBack), for: .touchUpInside)
         topBar.addSubview(backButton)
@@ -171,8 +171,8 @@ class CunningDocumentCropperViewController: UIViewController {
             // Back Button (Top Bar left)
             backButton.leadingAnchor.constraint(equalTo: topBar.leadingAnchor, constant: 15),
             backButton.centerYAnchor.constraint(equalTo: topBar.centerYAnchor),
-            backButton.widthAnchor.constraint(equalToConstant: 36),
-            backButton.heightAnchor.constraint(equalToConstant: 36),
+            backButton.widthAnchor.constraint(equalToConstant: 44),
+            backButton.heightAnchor.constraint(equalToConstant: 44),
             
             // Activity Indicator
             activityIndicator.centerXAnchor.constraint(equalTo: view.centerXAnchor),
@@ -186,6 +186,8 @@ class CunningDocumentCropperViewController: UIViewController {
             
             titleLabel.centerXAnchor.constraint(equalTo: topBar.centerXAnchor),
             titleLabel.centerYAnchor.constraint(equalTo: topBar.centerYAnchor),
+            titleLabel.leadingAnchor.constraint(greaterThanOrEqualTo: backButton.trailingAnchor, constant: 12),
+            titleLabel.trailingAnchor.constraint(lessThanOrEqualTo: topBar.trailingAnchor, constant: -12),
             
             // Bottom Bar
             bottomBar.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
@@ -333,7 +335,22 @@ class CunningDocumentCropperViewController: UIViewController {
     }
     
     @objc private func handleCancel() {
-        delegate?.didCancelCropping()
+        let hasChanges = hasUserModifiedPoints || currentIndex > 0
+        if hasChanges {
+            let alertTitle = localize("cunning_document_scanner_discard_title", "Discard changes?")
+            let alertMessage = localize("cunning_document_scanner_discard_message", "Are you sure you want to discard your progress?")
+            let cancelText = localize("cunning_document_scanner_cancel", "Cancel")
+            let discardText = localize("cunning_document_scanner_discard", "Discard")
+            
+            let alert = UIAlertController(title: alertTitle, message: alertMessage, preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: cancelText, style: .cancel, handler: nil))
+            alert.addAction(UIAlertAction(title: discardText, style: .destructive, handler: { [weak self] _ in
+                self?.delegate?.didCancelCropping()
+            }))
+            present(alert, animated: true, completion: nil)
+        } else {
+            delegate?.didCancelCropping()
+        }
     }
     
     @objc private func handleDone() {
@@ -460,6 +477,7 @@ class CroppingOverlayView: UIView {
     
     private var handles: [UIView] = []
     private let handleSize: CGFloat = 34
+    private var magnifierView: MagnifierView?
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -525,6 +543,44 @@ class CroppingOverlayView: UIView {
         
         onPointsChanged?()
         setNeedsDisplay()
+        
+        // Magnifier View updates
+        let touchPointInSelf = newCenter
+        guard let parentView = self.superview else { return }
+        let touchPointInParent = self.convert(touchPointInSelf, to: parentView)
+        
+        switch gesture.state {
+        case .began:
+            let magnifier = MagnifierView(frame: CGRect(x: 0, y: 0, width: 90, height: 90))
+            magnifier.viewToMagnify = parentView
+            parentView.addSubview(magnifier)
+            self.magnifierView = magnifier
+            updateMagnifier(touchPoint: touchPointInParent)
+        case .changed:
+            updateMagnifier(touchPoint: touchPointInParent)
+        case .ended, .cancelled:
+            magnifierView?.removeFromSuperview()
+            magnifierView = nil
+        default:
+            break
+        }
+    }
+    
+    private func updateMagnifier(touchPoint: CGPoint) {
+        guard let magnifier = magnifierView, let parentView = self.superview else { return }
+        magnifier.touchPoint = touchPoint
+        
+        // Position the magnifier offset above the touch point
+        var magnifierCenter = CGPoint(x: touchPoint.x, y: touchPoint.y - 75)
+        
+        // Keep the magnifier within the parent view bounds
+        let halfWidth = magnifier.bounds.width / 2
+        let halfHeight = magnifier.bounds.height / 2
+        
+        magnifierCenter.x = max(halfWidth, min(parentView.bounds.width - halfWidth, magnifierCenter.x))
+        magnifierCenter.y = max(halfHeight, min(parentView.bounds.height - halfHeight, magnifierCenter.y))
+        
+        magnifier.center = magnifierCenter
     }
     
     override func draw(_ rect: CGRect) {
@@ -591,5 +647,67 @@ extension UIImage {
             // Draw the image centered
             self.draw(in: CGRect(x: -size.width / 2, y: -size.height / 2, width: size.width, height: size.height))
         }
+    }
+}
+
+// MARK: - MagnifierView
+
+class MagnifierView: UIView {
+    var viewToMagnify: UIView?
+    var touchPoint: CGPoint = .zero {
+        didSet {
+            setNeedsDisplay()
+        }
+    }
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        backgroundColor = .clear
+        layer.shadowColor = UIColor.black.cgColor
+        layer.shadowOpacity = 0.5
+        layer.shadowOffset = CGSize(width: 0, height: 3)
+        layer.shadowRadius = 4
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func draw(_ rect: CGRect) {
+        guard let context = UIGraphicsGetCurrentContext(), let view = viewToMagnify else { return }
+        
+        // Circular clipping
+        let path = UIBezierPath(ovalIn: rect)
+        path.addClip()
+        
+        // Temporarily hide magnifier view to avoid rendering itself
+        let wasHidden = self.isHidden
+        self.isHidden = true
+        
+        context.translateBy(x: rect.width / 2, y: rect.height / 2)
+        context.scaleBy(x: 1.5, y: 1.5)
+        context.translateBy(x: -touchPoint.x, y: -touchPoint.y)
+        
+        view.layer.render(in: context)
+        
+        self.isHidden = wasHidden
+        
+        // Draw border ring
+        UIColor.white.setStroke()
+        let borderPath = UIBezierPath(ovalIn: rect.insetBy(dx: 1.5, dy: 1.5))
+        borderPath.lineWidth = 3
+        borderPath.stroke()
+        
+        // Draw crosshair in the center
+        UIColor.systemBlue.setStroke()
+        let crosshair = UIBezierPath()
+        let midX = rect.midX
+        let midY = rect.midY
+        crosshair.move(to: CGPoint(x: midX - 8, y: midY))
+        crosshair.addLine(to: CGPoint(x: midX + 8, y: midY))
+        crosshair.move(to: CGPoint(x: midX, y: midY - 8))
+        crosshair.addLine(to: CGPoint(x: midX, y: midY + 8))
+        crosshair.lineWidth = 1.5
+        crosshair.stroke()
     }
 }

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/CunningDocumentCropperViewController.swift
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/CunningDocumentCropperViewController.swift
@@ -2,32 +2,66 @@ import UIKit
 import Vision
 import CoreImage
 
+/// Delegate protocol for CunningDocumentCropperViewController to notify its parent of cropping completion or cancellation.
 protocol CunningDocumentCropperDelegate: AnyObject {
+    /// Called when the user has successfully finished cropping all selected images.
+    /// - Parameter croppedImages: An array of final cropped and perspective-corrected images.
     func didFinishCropping(croppedImages: [UIImage])
+    
+    /// Called when the user cancels the cropping flow.
     func didCancelCropping()
 }
 
+/// View controller that provides an interactive multi-page document cropping interface.
+/// It displays selected images and overlays draggable handles to correct perspective skewing.
 class CunningDocumentCropperViewController: UIViewController {
+    
+    /// The delegate to handle cropping lifecycle events.
     weak var delegate: CunningDocumentCropperDelegate?
     
+    /// The array of original images to be cropped.
     private var images: [UIImage] = []
+    
+    /// The array of output cropped images populated during the flow.
     private var croppedImages: [UIImage] = []
+    
+    /// The index of the current page being cropped.
     private var currentIndex = 0
     
+    /// The UIImageView to display the page image.
     private let imageView = UIImageView()
+    
+    /// The overlay canvas containing handles and drawing the crop boundaries.
     private let overlayView = CroppingOverlayView()
+    
+    /// The top navigation bar view.
     private let topBar = UIView()
+    
+    /// The bottom control bar view.
     private let bottomBar = UIView()
     
+    /// The label showing page progress (e.g. "Crop Page 1 of 3").
     private let titleLabel = UILabel()
+    
+    /// The button to dismiss the cropping view.
     private let cancelButton = UIButton(type: .system)
+    
+    /// The button to advance to the next page or finish.
     private let doneButton = UIButton(type: .system)
+    
+    /// The button to rotate the current page clockwise.
     private let rotateButton = UIButton(type: .system)
+    
+    /// The back button to return to the previous page.
     private let backButton = UIButton(type: .system)
     
+    /// The activity spinner shown during background image loading/processing.
     private let activityIndicator = UIActivityIndicatorView(style: .large)
+    
+    /// The CoreImage context used to execute perspective correction filters.
     private let ciContext = CIContext(options: nil)
     
+    /// A structure representing normalized corner coordinates of a page (0.0 to 1.0, bottom-left origin).
     private struct PageCoordinates {
         let topLeft: CGPoint
         let topRight: CGPoint
@@ -35,11 +69,19 @@ class CunningDocumentCropperViewController: UIViewController {
         let bottomRight: CGPoint
     }
     
+    /// A list mapping page indexes to their last saved/detected cropping coordinates.
     private var savedCoordinates: [PageCoordinates?] = []
     
+    /// Indicates whether the initial corner points have been set up for the current page.
     private var hasSetupPoints = false
+    
+    /// Indicates whether the user has interacted with the corner handles.
     private var hasUserModifiedPoints = false
+    
+    /// The current image under review with fixed orientation.
     private var currentNormalizedImage: UIImage?
+    
+    /// A closure used to retrieve localized option strings from the main plugin.
     private let localize: (String, String) -> String
     
     // Normalized coordinates (origin at bottom-left)
@@ -48,6 +90,10 @@ class CunningDocumentCropperViewController: UIViewController {
     private var normBottomLeft = CGPoint(x: 0.15, y: 0.15)
     private var normBottomRight = CGPoint(x: 0.85, y: 0.15)
     
+    /// Initializes a new cropper view controller with a list of images and a localizer.
+    /// - Parameters:
+    ///   - images: The list of raw images to crop.
+    ///   - localize: A closure to retrieve localized translation strings.
     init(images: [UIImage], localize: @escaping (String, String) -> String) {
         self.localize = localize
         self.images = images
@@ -84,6 +130,7 @@ class CunningDocumentCropperViewController: UIViewController {
         }
     }
     
+    /// Sets up and configures subviews and actions.
     private func setupViews() {
         // Image View configuration
         imageView.contentMode = .scaleAspectFit
@@ -155,6 +202,7 @@ class CunningDocumentCropperViewController: UIViewController {
         loadCurrentImage()
     }
     
+    /// Activates Auto Layout constraints for the interface components.
     private func setupConstraints() {
         imageView.translatesAutoresizingMaskIntoConstraints = false
         overlayView.translatesAutoresizingMaskIntoConstraints = false
@@ -224,6 +272,8 @@ class CunningDocumentCropperViewController: UIViewController {
         ])
     }
     
+    /// Loads and processes the image corresponding to the current index.
+    /// Normalizes orientation on a global background thread prior to displaying.
     private func loadCurrentImage() {
         guard currentIndex < images.count else { return }
         
@@ -302,6 +352,8 @@ class CunningDocumentCropperViewController: UIViewController {
         }
     }
     
+    /// Detects document boundary coordinates asynchronously using Vision Framework (iOS 15.0+),
+    /// defaulting to a standard inset box if detection fails or is unavailable.
     private func detectAndSetupPoints() {
         guard currentIndex < images.count else { return }
         guard let currentImage = self.currentNormalizedImage else { return }
@@ -344,6 +396,7 @@ class CunningDocumentCropperViewController: UIViewController {
         }
     }
     
+    /// Updates the overlay view's handle positions to match current normalized coordinate variables.
     private func updateHandlesToMatchNormalizedPoints() {
         let frame = getContentFrame()
         overlayView.topLeft = overlayView.viewPoint(fromNormalized: normTopLeft, contentFrame: frame)
@@ -353,6 +406,7 @@ class CunningDocumentCropperViewController: UIViewController {
         overlayView.updateHandlePositions()
     }
     
+    /// Calculates the size and origin of the aspect-fit image as it appears inside the UIImageView.
     private func getContentFrame() -> CGRect {
         guard let image = imageView.image else { return .zero }
         let imgSize = image.size
@@ -374,6 +428,7 @@ class CunningDocumentCropperViewController: UIViewController {
         return CGRect(x: x, y: y, width: contentW, height: contentH)
     }
     
+    /// Responds to cancel actions, prompting a discard confirmation alert if modifications are present.
     @objc private func handleCancel() {
         let hasChanges = hasUserModifiedPoints || currentIndex > 0
         if hasChanges {
@@ -393,6 +448,7 @@ class CunningDocumentCropperViewController: UIViewController {
         }
     }
     
+    /// Confirms selection of current page crop, performs perspective correction, and advances progress.
     @objc private func handleDone() {
         guard currentIndex < images.count else { return }
         guard let currentImage = self.currentNormalizedImage else { return }
@@ -458,6 +514,7 @@ class CunningDocumentCropperViewController: UIViewController {
         }
     }
     
+    /// Rotates the image metadata and corner crop coordinates 90 degrees clockwise instantly.
     @objc private func handleRotate() {
         guard currentIndex < images.count else { return }
         guard let currentImage = self.currentNormalizedImage else { return }
@@ -497,6 +554,7 @@ class CunningDocumentCropperViewController: UIViewController {
         }
     }
     
+    /// Navigates back to the previous page in the list.
     @objc private func handleBack() {
         guard currentIndex > 0 else { return }
         
@@ -509,6 +567,7 @@ class CunningDocumentCropperViewController: UIViewController {
         loadCurrentImage()
     }
     
+    /// Applies CIPerspectiveCorrection to un-skew and crop the document area based on specified corner points.
     private func cropImage(image: UIImage, topLeft: CGPoint, topRight: CGPoint, bottomLeft: CGPoint, bottomRight: CGPoint) -> UIImage? {
         guard let rawCIImage = CIImage(image: image) else { return nil }
         let ciImage = rawCIImage.oriented(CGImagePropertyOrientation(image.imageOrientation))
@@ -535,317 +594,5 @@ class CunningDocumentCropperViewController: UIViewController {
         guard let cgImage = self.ciContext.createCGImage(outputImage, from: outputImage.extent) else { return nil }
         
         return UIImage(cgImage: cgImage)
-    }
-}
-
-// MARK: - CroppingOverlayView
-
-class CroppingOverlayView: UIView {
-    var topLeft = CGPoint.zero
-    var topRight = CGPoint.zero
-    var bottomLeft = CGPoint.zero
-    var bottomRight = CGPoint.zero
-    
-    var contentFrame = CGRect.zero
-    var onPointsChanged: (() -> Void)?
-    
-    private var handles: [UIView] = []
-    private let handleSize: CGFloat = 34
-    private var magnifierView: MagnifierView?
-    private var activeHandle: UIView?
-    
-    override init(frame: CGRect) {
-        super.init(frame: frame)
-        backgroundColor = .clear
-        setupHandles()
-    }
-    
-    required init?(coder: NSCoder) {
-        super.init(coder: coder)
-        backgroundColor = .clear
-        setupHandles()
-    }
-    
-    private func setupHandles() {
-        for i in 0..<4 {
-            let handle = UIView(frame: CGRect(x: 0, y: 0, width: handleSize, height: handleSize))
-            handle.backgroundColor = UIColor.systemBlue.withAlphaComponent(0.8)
-            handle.layer.cornerRadius = handleSize / 2
-            handle.layer.borderWidth = 3
-            handle.layer.borderColor = UIColor.white.cgColor
-            handle.tag = i
-            
-            let pan = UIPanGestureRecognizer(target: self, action: #selector(handlePan(_:)))
-            handle.addGestureRecognizer(pan)
-            addSubview(handle)
-            handles.append(handle)
-        }
-    }
-    
-    func updateHandlePositions() {
-        guard handles.count == 4 else { return }
-        handles[0].center = topLeft
-        handles[1].center = topRight
-        handles[2].center = bottomLeft
-        handles[3].center = bottomRight
-        setNeedsDisplay()
-    }
-    
-    @objc private func handlePan(_ gesture: UIPanGestureRecognizer) {
-        guard let handle = gesture.view else { return }
-        
-        if let active = activeHandle, active !== handle {
-            return
-        }
-        
-        let translation = gesture.translation(in: self)
-        var newCenter = CGPoint(x: handle.center.x + translation.x, y: handle.center.y + translation.y)
-        
-        // Restrict drag inside the image content frame (if set)
-        if contentFrame != .zero {
-            newCenter.x = max(contentFrame.minX, min(contentFrame.maxX, newCenter.x))
-            newCenter.y = max(contentFrame.minY, min(contentFrame.maxY, newCenter.y))
-        } else {
-            newCenter.x = max(0, min(bounds.width, newCenter.x))
-            newCenter.y = max(0, min(bounds.height, newCenter.y))
-        }
-        
-        handle.center = newCenter
-        gesture.setTranslation(.zero, in: self)
-        
-        switch handle.tag {
-        case 0: topLeft = newCenter
-        case 1: topRight = newCenter
-        case 2: bottomLeft = newCenter
-        case 3: bottomRight = newCenter
-        default: break
-        }
-        
-        onPointsChanged?()
-        setNeedsDisplay()
-        
-        // Magnifier View updates
-        let touchPointInSelf = newCenter
-        guard let parentView = self.superview else { return }
-        let touchPointInParent = self.convert(touchPointInSelf, to: parentView)
-        
-        switch gesture.state {
-        case .began:
-            activeHandle = handle
-            let magnifier = MagnifierView(frame: CGRect(x: 0, y: 0, width: 90, height: 90))
-            
-            // Temporarily hide the overlay view so it isn't captured in the zoom lens background
-            self.isHidden = true
-            
-            // Snapshot the parent view once
-            let renderer = UIGraphicsImageRenderer(size: parentView.bounds.size)
-            let snapshot = renderer.image { ctx in
-                parentView.layer.render(in: ctx.cgContext)
-            }
-            
-            // Restore visibility
-            self.isHidden = false
-            
-            magnifier.snapshotImage = snapshot
-            parentView.addSubview(magnifier)
-            self.magnifierView = magnifier
-            updateMagnifier(touchPoint: touchPointInParent, touchPointInSelf: touchPointInParent)
-        case .changed:
-            updateMagnifier(touchPoint: touchPointInParent, touchPointInSelf: touchPointInParent)
-        case .ended, .cancelled:
-            magnifierView?.removeFromSuperview()
-            magnifierView = nil
-            activeHandle = nil
-        default:
-            break
-        }
-    }
-    
-    private func updateMagnifier(touchPoint: CGPoint, touchPointInSelf: CGPoint) {
-        guard let magnifier = magnifierView, let parentView = self.superview else { return }
-        magnifier.touchPoint = touchPointInSelf
-        
-        let halfHeight = magnifier.bounds.height / 2
-        
-        // Position the magnifier offset above the touch point.
-        // If the touch point is too close to the top, position it below the touch point to avoid going off-screen or being covered by the finger.
-        let isNearTop = (touchPoint.y - 75) < halfHeight
-        let yOffset: CGFloat = isNearTop ? 75 : -75
-        var magnifierCenter = CGPoint(x: touchPoint.x, y: touchPoint.y + yOffset)
-        
-        // Keep the magnifier within the parent view bounds
-        let halfWidth = magnifier.bounds.width / 2
-        
-        magnifierCenter.x = max(halfWidth, min(parentView.bounds.width - halfWidth, magnifierCenter.x))
-        magnifierCenter.y = max(halfHeight, min(parentView.bounds.height - halfHeight, magnifierCenter.y))
-        
-        magnifier.center = magnifierCenter
-    }
-    
-    override func draw(_ rect: CGRect) {
-        guard topLeft != .zero || topRight != .zero || bottomLeft != .zero || bottomRight != .zero else {
-            return
-        }
-        
-        let path = UIBezierPath()
-        path.move(to: topLeft)
-        path.addLine(to: topRight)
-        path.addLine(to: bottomRight)
-        path.addLine(to: bottomLeft)
-        path.close()
-        
-        // Draw fill area
-        UIColor.systemBlue.withAlphaComponent(0.25).setFill()
-        path.fill()
-        
-        // Draw crop frame lines
-        UIColor.systemBlue.setStroke()
-        path.lineWidth = 3
-        path.stroke()
-    }
-    
-    // Convert points coordinate mappings
-    func viewPoint(fromNormalized point: CGPoint, contentFrame: CGRect) -> CGPoint {
-        guard contentFrame.width > 0 && contentFrame.height > 0 else { return .zero }
-        let vx = contentFrame.origin.x + point.x * contentFrame.size.width
-        let vy = contentFrame.origin.y + (1.0 - point.y) * contentFrame.size.height
-        return CGPoint(x: vx, y: vy)
-    }
-    
-    func normalizedPoint(fromView point: CGPoint, contentFrame: CGRect) -> CGPoint {
-        guard contentFrame.width > 0 && contentFrame.height > 0 else { return .zero }
-        let px = (point.x - contentFrame.origin.x) / contentFrame.size.width
-        let py = 1.0 - (point.y - contentFrame.origin.y) / contentFrame.size.height
-        return CGPoint(x: max(0.0, min(1.0, px)), y: max(0.0, min(1.0, py)))
-    }
-}
-
-// MARK: - UIImage Extension (Fix Orientation)
-
-extension UIImage {
-    func fixedOrientation() -> UIImage {
-        if imageOrientation == .up { return self }
-        
-        let format = UIGraphicsImageRendererFormat.default()
-        format.scale = self.scale
-        let renderer = UIGraphicsImageRenderer(size: size, format: format)
-        return renderer.image { _ in
-            self.draw(in: CGRect(origin: .zero, size: size))
-        }
-    }
-    
-    func rotated90Clockwise() -> UIImage? {
-        let newOrientation: UIImage.Orientation
-        switch self.imageOrientation {
-        case .up: newOrientation = .right
-        case .right: newOrientation = .down
-        case .down: newOrientation = .left
-        case .left: newOrientation = .up
-        case .upMirrored: newOrientation = .rightMirrored
-        case .rightMirrored: newOrientation = .downMirrored
-        case .downMirrored: newOrientation = .leftMirrored
-        case .leftMirrored: newOrientation = .upMirrored
-        @unknown default: newOrientation = .right
-        }
-        
-        if let cgImage = self.cgImage {
-            return UIImage(cgImage: cgImage, scale: self.scale, orientation: newOrientation)
-        } else if let ciImage = self.ciImage {
-            return UIImage(ciImage: ciImage, scale: self.scale, orientation: newOrientation)
-        }
-        return nil
-    }
-    
-    func downscaled(toMaxDimension maxDimension: CGFloat) -> UIImage {
-        let size = self.size
-        let maxDim = max(size.width, size.height)
-        if maxDim <= maxDimension {
-            return self
-        }
-        
-        let scale = maxDimension / maxDim
-        let newSize = CGSize(width: size.width * scale, height: size.height * scale)
-        
-        let format = UIGraphicsImageRendererFormat.default()
-        format.scale = 1.0 // Use 1.0 scale to keep exact pixel dimensions
-        let renderer = UIGraphicsImageRenderer(size: newSize, format: format)
-        
-        return renderer.image { _ in
-            self.draw(in: CGRect(origin: .zero, size: newSize))
-        }
-    }
-}
-
-// MARK: - MagnifierView
-
-class MagnifierView: UIView {
-    var snapshotImage: UIImage?
-    var touchPoint: CGPoint = .zero {
-        didSet {
-            setNeedsDisplay()
-        }
-    }
-    
-    override init(frame: CGRect) {
-        super.init(frame: frame)
-        backgroundColor = .clear
-        layer.shadowColor = UIColor.black.cgColor
-        layer.shadowOpacity = 0.5
-        layer.shadowOffset = CGSize(width: 0, height: 3)
-        layer.shadowRadius = 4
-    }
-    
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-    
-    override func draw(_ rect: CGRect) {
-        guard let context = UIGraphicsGetCurrentContext(), let image = snapshotImage else { return }
-        
-        // Circular clipping
-        let path = UIBezierPath(ovalIn: rect)
-        path.addClip()
-        
-        context.translateBy(x: rect.width / 2, y: rect.height / 2)
-        context.scaleBy(x: 1.5, y: 1.5)
-        context.translateBy(x: -touchPoint.x, y: -touchPoint.y)
-        
-        image.draw(at: .zero)
-        
-        // Draw border ring
-        UIColor.white.setStroke()
-        let borderPath = UIBezierPath(ovalIn: rect.insetBy(dx: 1.5, dy: 1.5))
-        borderPath.lineWidth = 3
-        borderPath.stroke()
-        
-        // Draw crosshair in the center
-        UIColor.systemBlue.setStroke()
-        let crosshair = UIBezierPath()
-        let midX = rect.midX
-        let midY = rect.midY
-        crosshair.move(to: CGPoint(x: midX - 8, y: midY))
-        crosshair.addLine(to: CGPoint(x: midX + 8, y: midY))
-        crosshair.move(to: CGPoint(x: midX, y: midY - 8))
-        crosshair.addLine(to: CGPoint(x: midX, y: midY + 8))
-        crosshair.lineWidth = 1.5
-        crosshair.stroke()
-    }
-}
-
-// MARK: - CGImagePropertyOrientation Mapping Helper
-
-extension CGImagePropertyOrientation {
-    init(_ uiOrientation: UIImage.Orientation) {
-        switch uiOrientation {
-        case .up: self = .up
-        case .upMirrored: self = .upMirrored
-        case .down: self = .down
-        case .downMirrored: self = .downMirrored
-        case .leftMirrored: self = .leftMirrored
-        case .right: self = .right
-        case .rightMirrored: self = .rightMirrored
-        case .left: self = .left
-        @unknown default: self = .up
-        }
     }
 }

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/CunningDocumentCropperViewController.swift
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/CunningDocumentCropperViewController.swift
@@ -22,8 +22,14 @@ class CunningDocumentCropperViewController: UIViewController {
     private let titleLabel = UILabel()
     private let cancelButton = UIButton(type: .system)
     private let doneButton = UIButton(type: .system)
+    private let rotateButton = UIButton(type: .system)
+    
+    private let activityIndicator = UIActivityIndicatorView(style: .large)
+    private let ciContext = CIContext(options: nil)
     
     private var hasSetupPoints = false
+    private var hasUserModifiedPoints = false
+    private var currentNormalizedImage: UIImage?
     private let localize: (String, String) -> String
     
     // Normalized coordinates (origin at bottom-left)
@@ -34,9 +40,12 @@ class CunningDocumentCropperViewController: UIViewController {
     
     init(images: [UIImage], localize: @escaping (String, String) -> String) {
         self.localize = localize
+        self.images = images
         super.init(nibName: nil, bundle: nil)
-        // Normalize orientations of all images first
-        self.images = images.map { $0.fixedOrientation() }
+    }
+    
+    override var preferredStatusBarStyle: UIStatusBarStyle {
+        return .lightContent
     }
     
     required init?(coder: NSCoder) {
@@ -73,6 +82,7 @@ class CunningDocumentCropperViewController: UIViewController {
         // Overlay View configuration
         overlayView.onPointsChanged = { [weak self] in
             guard let self = self else { return }
+            self.hasUserModifiedPoints = true
             let frame = self.getContentFrame()
             self.normTopLeft = self.overlayView.normalizedPoint(fromView: self.overlayView.topLeft, contentFrame: frame)
             self.normTopRight = self.overlayView.normalizedPoint(fromView: self.overlayView.topRight, contentFrame: frame)
@@ -80,6 +90,11 @@ class CunningDocumentCropperViewController: UIViewController {
             self.normBottomRight = self.overlayView.normalizedPoint(fromView: self.overlayView.bottomRight, contentFrame: frame)
         }
         view.addSubview(overlayView)
+        
+        // Activity Indicator configuration
+        activityIndicator.color = .white
+        activityIndicator.hidesWhenStopped = true
+        view.addSubview(activityIndicator)
         
         // Top Bar configuration
         topBar.backgroundColor = UIColor.black.withAlphaComponent(0.6)
@@ -94,17 +109,28 @@ class CunningDocumentCropperViewController: UIViewController {
         bottomBar.backgroundColor = UIColor.black.withAlphaComponent(0.6)
         view.addSubview(bottomBar)
         
-        cancelButton.setTitle(localize("cunning_document_scanner_cancel", "Cancel"), for: .normal)
-        cancelButton.setTitleColor(.systemRed, for: .normal)
-        cancelButton.titleLabel?.font = UIFont.systemFont(ofSize: 16, weight: .medium)
+        let config = UIImage.SymbolConfiguration(pointSize: 18, weight: .medium)
+        
+        cancelButton.setImage(UIImage(systemName: "xmark", withConfiguration: config), for: .normal)
+        cancelButton.tintColor = .black
+        cancelButton.backgroundColor = .white
+        cancelButton.layer.cornerRadius = 22
+        cancelButton.clipsToBounds = true
         cancelButton.addTarget(self, action: #selector(handleCancel), for: .touchUpInside)
         bottomBar.addSubview(cancelButton)
         
-        doneButton.setTitle(localize("cunning_document_scanner_next", "Next"), for: .normal)
-        doneButton.setTitleColor(.systemBlue, for: .normal)
-        doneButton.titleLabel?.font = UIFont.systemFont(ofSize: 16, weight: .bold)
+        doneButton.layer.cornerRadius = 22
+        doneButton.clipsToBounds = true
         doneButton.addTarget(self, action: #selector(handleDone), for: .touchUpInside)
         bottomBar.addSubview(doneButton)
+        
+        rotateButton.setImage(UIImage(systemName: "rotate.right", withConfiguration: config), for: .normal)
+        rotateButton.tintColor = .white
+        rotateButton.backgroundColor = UIColor.white.withAlphaComponent(0.15)
+        rotateButton.layer.cornerRadius = 22
+        rotateButton.clipsToBounds = true
+        rotateButton.addTarget(self, action: #selector(handleRotate), for: .touchUpInside)
+        bottomBar.addSubview(rotateButton)
         
         loadCurrentImage()
     }
@@ -117,8 +143,14 @@ class CunningDocumentCropperViewController: UIViewController {
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
         cancelButton.translatesAutoresizingMaskIntoConstraints = false
         doneButton.translatesAutoresizingMaskIntoConstraints = false
+        rotateButton.translatesAutoresizingMaskIntoConstraints = false
+        activityIndicator.translatesAutoresizingMaskIntoConstraints = false
         
         NSLayoutConstraint.activate([
+            // Activity Indicator
+            activityIndicator.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            activityIndicator.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+            
             // Top Bar
             topBar.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
             topBar.leadingAnchor.constraint(equalTo: view.leadingAnchor),
@@ -136,9 +168,18 @@ class CunningDocumentCropperViewController: UIViewController {
             
             cancelButton.leadingAnchor.constraint(equalTo: bottomBar.leadingAnchor, constant: 20),
             cancelButton.centerYAnchor.constraint(equalTo: bottomBar.centerYAnchor),
+            cancelButton.widthAnchor.constraint(equalToConstant: 44),
+            cancelButton.heightAnchor.constraint(equalToConstant: 44),
             
             doneButton.trailingAnchor.constraint(equalTo: bottomBar.trailingAnchor, constant: -20),
             doneButton.centerYAnchor.constraint(equalTo: bottomBar.centerYAnchor),
+            doneButton.widthAnchor.constraint(equalToConstant: 44),
+            doneButton.heightAnchor.constraint(equalToConstant: 44),
+            
+            rotateButton.centerXAnchor.constraint(equalTo: bottomBar.centerXAnchor),
+            rotateButton.centerYAnchor.constraint(equalTo: bottomBar.centerYAnchor),
+            rotateButton.widthAnchor.constraint(equalToConstant: 44),
+            rotateButton.heightAnchor.constraint(equalToConstant: 44),
             
             // Image View (fills space between top and bottom bar)
             imageView.topAnchor.constraint(equalTo: topBar.bottomAnchor),
@@ -157,7 +198,8 @@ class CunningDocumentCropperViewController: UIViewController {
     private func loadCurrentImage() {
         guard currentIndex < images.count else { return }
         
-        let currentImage = images[currentIndex]
+        let currentImage = images[currentIndex].fixedOrientation()
+        self.currentNormalizedImage = currentImage
         imageView.image = currentImage
         
         // Update Title and Done Button Label
@@ -165,19 +207,23 @@ class CunningDocumentCropperViewController: UIViewController {
         let titleFormat = localize("cunning_document_scanner_crop_title", "Crop Page %d of %d")
         titleLabel.text = String(format: titleFormat, pageNum, images.count)
         
-        let doneTitle = (currentIndex == images.count - 1)
-            ? localize("cunning_document_scanner_done", "Done")
-            : localize("cunning_document_scanner_next", "Next")
-        doneButton.setTitle(doneTitle, for: .normal)
+        let isLastPage = (currentIndex == images.count - 1)
+        let config = UIImage.SymbolConfiguration(pointSize: 18, weight: .bold)
+        let doneImageName = isLastPage ? "checkmark" : "arrow.right"
+        let doneImage = UIImage(systemName: doneImageName, withConfiguration: config)
+        doneButton.setImage(doneImage, for: .normal)
+        doneButton.tintColor = .white
+        doneButton.backgroundColor = .systemBlue
         
         // Reset flags for the new image detection
         hasSetupPoints = false
+        hasUserModifiedPoints = false
         view.setNeedsLayout()
     }
     
     private func detectAndSetupPoints() {
         guard currentIndex < images.count else { return }
-        let currentImage = images[currentIndex]
+        guard let currentImage = self.currentNormalizedImage else { return }
         
         // Set default points initially
         self.normTopLeft = CGPoint(x: 0.15, y: 0.85)
@@ -187,29 +233,33 @@ class CunningDocumentCropperViewController: UIViewController {
         
         self.updateHandlesToMatchNormalizedPoints()
         
-        // Run vision detection asynchronously
-        guard let cgImage = currentImage.cgImage else { return }
-        let request = VNDetectDocumentSegmentationRequest { [weak self] request, error in
-            guard let self = self else { return }
-            guard error == nil,
-                  let results = request.results as? [VNRectangleObservation],
-                  let firstResult = results.first else {
-                return // Use defaults
+        if #available(iOS 15.0, *) {
+            // Run vision detection asynchronously
+            guard let cgImage = currentImage.cgImage else { return }
+            let requestIndex = self.currentIndex
+            let request = VNDetectDocumentSegmentationRequest { [weak self] request, error in
+                guard let self = self else { return }
+                guard error == nil,
+                      let results = request.results as? [VNRectangleObservation],
+                      let firstResult = results.first else {
+                    return // Use defaults
+                }
+                
+                DispatchQueue.main.async {
+                    // Verify we are still on the same image and user hasn't modified points manually
+                    guard self.currentIndex == requestIndex, !self.hasUserModifiedPoints else { return }
+                    self.normTopLeft = firstResult.topLeft
+                    self.normTopRight = firstResult.topRight
+                    self.normBottomLeft = firstResult.bottomLeft
+                    self.normBottomRight = firstResult.bottomRight
+                    self.updateHandlesToMatchNormalizedPoints()
+                }
             }
             
-            DispatchQueue.main.async {
-                // Verify we are still on the same image
-                self.normTopLeft = firstResult.topLeft
-                self.normTopRight = firstResult.topRight
-                self.normBottomLeft = firstResult.bottomLeft
-                self.normBottomRight = firstResult.bottomRight
-                self.updateHandlesToMatchNormalizedPoints()
+            let handler = VNImageRequestHandler(cgImage: cgImage, options: [:])
+            DispatchQueue.global(qos: .userInitiated).async {
+                try? handler.perform([request])
             }
-        }
-        
-        let handler = VNImageRequestHandler(cgImage: cgImage, options: [:])
-        DispatchQueue.global(qos: .userInitiated).async {
-            try? handler.perform([request])
         }
     }
     
@@ -249,12 +299,13 @@ class CunningDocumentCropperViewController: UIViewController {
     
     @objc private func handleDone() {
         guard currentIndex < images.count else { return }
+        guard let currentImage = self.currentNormalizedImage else { return }
         
         // Show spinner / block buttons to prevent double-tap
         cancelButton.isEnabled = false
         doneButton.isEnabled = false
-        
-        let currentImage = images[currentIndex]
+        rotateButton.isEnabled = false
+        activityIndicator.startAnimating()
         
         // Crop the current image on a background thread
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
@@ -271,6 +322,8 @@ class CunningDocumentCropperViewController: UIViewController {
             DispatchQueue.main.async {
                 self.cancelButton.isEnabled = true
                 self.doneButton.isEnabled = true
+                self.rotateButton.isEnabled = true
+                self.activityIndicator.stopAnimating()
                 
                 if let cropped = cropped {
                     self.croppedImages.append(cropped)
@@ -289,11 +342,26 @@ class CunningDocumentCropperViewController: UIViewController {
         }
     }
     
+    @objc private func handleRotate() {
+        guard currentIndex < images.count else { return }
+        guard let currentImage = self.currentNormalizedImage else { return }
+        
+        if let rotated = currentImage.rotated90Clockwise() {
+            self.images[currentIndex] = rotated
+            self.currentNormalizedImage = rotated
+            self.imageView.image = rotated
+            
+            // Reset flags to force handle calculation on rotated dimensions
+            hasSetupPoints = false
+            view.setNeedsLayout()
+        }
+    }
+    
     private func cropImage(image: UIImage, topLeft: CGPoint, topRight: CGPoint, bottomLeft: CGPoint, bottomRight: CGPoint) -> UIImage? {
         guard let ciImage = CIImage(image: image) else { return nil }
         
-        let w = image.size.width
-        let h = image.size.height
+        let w = ciImage.extent.width
+        let h = ciImage.extent.height
         
         let tl = CIVector(x: topLeft.x * w, y: topLeft.y * h)
         let tr = CIVector(x: topRight.x * w, y: topRight.y * h)
@@ -309,8 +377,7 @@ class CunningDocumentCropperViewController: UIViewController {
         
         guard let outputImage = filter.outputImage else { return nil }
         
-        let context = CIContext(options: nil)
-        guard let cgImage = context.createCGImage(outputImage, from: outputImage.extent) else { return nil }
+        guard let cgImage = self.ciContext.createCGImage(outputImage, from: outputImage.extent) else { return nil }
         
         return UIImage(cgImage: cgImage)
     }
@@ -344,7 +411,7 @@ class CroppingOverlayView: UIView {
     
     private func setupHandles() {
         for i in 0..<4 {
-            let handle = UIView()
+            let handle = UIView(frame: CGRect(x: 0, y: 0, width: handleSize, height: handleSize))
             handle.backgroundColor = UIColor.systemBlue.withAlphaComponent(0.8)
             handle.layer.cornerRadius = handleSize / 2
             handle.layer.borderWidth = 3
@@ -440,11 +507,25 @@ extension UIImage {
     func fixedOrientation() -> UIImage {
         if imageOrientation == .up { return self }
         
-        UIGraphicsBeginImageContextWithOptions(size, false, scale)
-        draw(in: CGRect(origin: .zero, size: size))
-        let normalizedImage = UIGraphicsGetImageFromCurrentImageContext()
-        UIGraphicsEndImageContext()
+        let renderer = UIGraphicsImageRenderer(size: size)
+        return renderer.image { _ in
+            self.draw(in: CGRect(origin: .zero, size: size))
+        }
+    }
+    
+    func rotated90Clockwise() -> UIImage? {
+        let newSize = CGSize(width: size.height, height: size.width)
+        let renderer = UIGraphicsImageRenderer(size: newSize)
         
-        return normalizedImage ?? self
+        return renderer.image { context in
+            let cgContext = context.cgContext
+            
+            // Move origin to the center and rotate
+            cgContext.translateBy(x: newSize.width / 2, y: newSize.height / 2)
+            cgContext.rotate(by: .pi / 2)
+            
+            // Draw the image centered
+            self.draw(in: CGRect(x: -size.width / 2, y: -size.height / 2, width: size.width, height: size.height))
+        }
     }
 }

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/CunningDocumentCropperViewController.swift
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/CunningDocumentCropperViewController.swift
@@ -227,9 +227,14 @@ class CunningDocumentCropperViewController: UIViewController {
     private func loadCurrentImage() {
         guard currentIndex < images.count else { return }
         
-        let currentImage = images[currentIndex].fixedOrientation()
-        self.currentNormalizedImage = currentImage
-        imageView.image = currentImage
+        let imageToProcess = images[currentIndex]
+        
+        // Show spinner and temporarily disable controls
+        activityIndicator.startAnimating()
+        doneButton.isEnabled = false
+        rotateButton.isEnabled = false
+        cancelButton.isEnabled = false
+        backButton.isEnabled = false
         
         // Update Title and Done Button Label
         let pageNum = currentIndex + 1
@@ -247,19 +252,54 @@ class CunningDocumentCropperViewController: UIViewController {
         // Show/hide back button based on page index
         backButton.isHidden = (currentIndex == 0)
         
-        // Restore coordinates if previously saved, otherwise run auto-detection
-        if let saved = savedCoordinates[currentIndex] {
-            self.normTopLeft = saved.topLeft
-            self.normTopRight = saved.topRight
-            self.normBottomLeft = saved.bottomLeft
-            self.normBottomRight = saved.bottomRight
-            self.hasSetupPoints = true
-            self.hasUserModifiedPoints = true
-        } else {
-            self.hasSetupPoints = false
-            self.hasUserModifiedPoints = false
+        // Perform fixedOrientation on a background thread with an autoreleasepool to save memory
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            guard let self = self else { return }
+            
+            var fixedImage: UIImage?
+            autoreleasepool {
+                fixedImage = imageToProcess.fixedOrientation()
+            }
+            
+            DispatchQueue.main.async {
+                // Ensure the user hasn't switched pages while we were processing
+                guard self.currentIndex < self.images.count, self.images[self.currentIndex] === imageToProcess else {
+                    return
+                }
+                
+                guard let resolvedImage = fixedImage else {
+                    self.activityIndicator.stopAnimating()
+                    self.doneButton.isEnabled = true
+                    self.rotateButton.isEnabled = true
+                    self.cancelButton.isEnabled = true
+                    self.backButton.isEnabled = !self.backButton.isHidden
+                    return
+                }
+                
+                self.currentNormalizedImage = resolvedImage
+                self.imageView.image = resolvedImage
+                
+                self.activityIndicator.stopAnimating()
+                self.doneButton.isEnabled = true
+                self.rotateButton.isEnabled = true
+                self.cancelButton.isEnabled = true
+                self.backButton.isEnabled = !self.backButton.isHidden
+                
+                // Restore coordinates if previously saved, otherwise run auto-detection
+                if let saved = self.savedCoordinates[self.currentIndex] {
+                    self.normTopLeft = saved.topLeft
+                    self.normTopRight = saved.topRight
+                    self.normBottomLeft = saved.bottomLeft
+                    self.normBottomRight = saved.bottomRight
+                    self.hasSetupPoints = true
+                    self.hasUserModifiedPoints = true
+                } else {
+                    self.hasSetupPoints = false
+                    self.hasUserModifiedPoints = false
+                }
+                self.view.setNeedsLayout()
+            }
         }
-        view.setNeedsLayout()
     }
     
     private func detectAndSetupPoints() {
@@ -376,13 +416,16 @@ class CunningDocumentCropperViewController: UIViewController {
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
             guard let self = self else { return }
             
-            let cropped = self.cropImage(
-                image: currentImage,
-                topLeft: self.normTopLeft,
-                topRight: self.normTopRight,
-                bottomLeft: self.normBottomLeft,
-                bottomRight: self.normBottomRight
-            )
+            var cropped: UIImage?
+            autoreleasepool {
+                cropped = self.cropImage(
+                    image: currentImage,
+                    topLeft: self.normTopLeft,
+                    topRight: self.normTopRight,
+                    bottomLeft: self.normBottomLeft,
+                    bottomRight: self.normBottomRight
+                )
+            }
             
             DispatchQueue.main.async {
                 self.cancelButton.isEnabled = true
@@ -417,12 +460,33 @@ class CunningDocumentCropperViewController: UIViewController {
             self.currentNormalizedImage = rotated
             self.imageView.image = rotated
             
-            // Clear any saved coordinates for this page to force re-detection on new orientation
-            self.savedCoordinates[currentIndex] = nil
+            // Rotate the normalized coordinates 90 degrees clockwise:
+            // x' = y
+            // y' = 1 - x
+            let oldTopLeft = self.normTopLeft
+            let oldTopRight = self.normTopRight
+            let oldBottomLeft = self.normBottomLeft
+            let oldBottomRight = self.normBottomRight
             
-            // Reset flags to force handle calculation on rotated dimensions
-            hasSetupPoints = false
+            self.normTopLeft = CGPoint(x: oldBottomLeft.y, y: 1.0 - oldBottomLeft.x)
+            self.normTopRight = CGPoint(x: oldTopLeft.y, y: 1.0 - oldTopLeft.x)
+            self.normBottomRight = CGPoint(x: oldTopRight.y, y: 1.0 - oldTopRight.x)
+            self.normBottomLeft = CGPoint(x: oldBottomRight.y, y: 1.0 - oldBottomRight.x)
+            
+            // Save the newly rotated coordinates
+            self.savedCoordinates[currentIndex] = PageCoordinates(
+                topLeft: self.normTopLeft,
+                topRight: self.normTopRight,
+                bottomLeft: self.normBottomLeft,
+                bottomRight: self.normBottomRight
+            )
+            
+            // Mark points as set up so we don't trigger Vision auto-detection again
+            hasSetupPoints = true
+            
+            // Force redraw of layout and update overlay handle positions
             view.setNeedsLayout()
+            view.layoutIfNeeded()
         }
     }
     
@@ -552,12 +616,25 @@ class CroppingOverlayView: UIView {
         switch gesture.state {
         case .began:
             let magnifier = MagnifierView(frame: CGRect(x: 0, y: 0, width: 90, height: 90))
-            magnifier.viewToMagnify = parentView
+            
+            // Temporarily hide the overlay view so it isn't captured in the zoom lens background
+            self.isHidden = true
+            
+            // Snapshot the parent view once
+            let renderer = UIGraphicsImageRenderer(size: parentView.bounds.size)
+            let snapshot = renderer.image { ctx in
+                parentView.layer.render(in: ctx.cgContext)
+            }
+            
+            // Restore visibility
+            self.isHidden = false
+            
+            magnifier.snapshotImage = snapshot
             parentView.addSubview(magnifier)
             self.magnifierView = magnifier
-            updateMagnifier(touchPoint: touchPointInParent)
+            updateMagnifier(touchPoint: touchPointInParent, touchPointInSelf: touchPointInParent)
         case .changed:
-            updateMagnifier(touchPoint: touchPointInParent)
+            updateMagnifier(touchPoint: touchPointInParent, touchPointInSelf: touchPointInParent)
         case .ended, .cancelled:
             magnifierView?.removeFromSuperview()
             magnifierView = nil
@@ -566,9 +643,9 @@ class CroppingOverlayView: UIView {
         }
     }
     
-    private func updateMagnifier(touchPoint: CGPoint) {
+    private func updateMagnifier(touchPoint: CGPoint, touchPointInSelf: CGPoint) {
         guard let magnifier = magnifierView, let parentView = self.superview else { return }
-        magnifier.touchPoint = touchPoint
+        magnifier.touchPoint = touchPointInSelf
         
         // Position the magnifier offset above the touch point
         var magnifierCenter = CGPoint(x: touchPoint.x, y: touchPoint.y - 75)
@@ -634,18 +711,40 @@ extension UIImage {
     }
     
     func rotated90Clockwise() -> UIImage? {
-        let newSize = CGSize(width: size.height, height: size.width)
-        let renderer = UIGraphicsImageRenderer(size: newSize)
+        guard let cgImage = self.cgImage else { return nil }
         
-        return renderer.image { context in
-            let cgContext = context.cgContext
-            
-            // Move origin to the center and rotate
-            cgContext.translateBy(x: newSize.width / 2, y: newSize.height / 2)
-            cgContext.rotate(by: .pi / 2)
-            
-            // Draw the image centered
-            self.draw(in: CGRect(x: -size.width / 2, y: -size.height / 2, width: size.width, height: size.height))
+        let newOrientation: UIImage.Orientation
+        switch self.imageOrientation {
+        case .up: newOrientation = .right
+        case .right: newOrientation = .down
+        case .down: newOrientation = .left
+        case .left: newOrientation = .up
+        case .upMirrored: newOrientation = .rightMirrored
+        case .rightMirrored: newOrientation = .downMirrored
+        case .downMirrored: newOrientation = .leftMirrored
+        case .leftMirrored: newOrientation = .upMirrored
+        @unknown default: newOrientation = .right
+        }
+        
+        return UIImage(cgImage: cgImage, scale: self.scale, orientation: newOrientation)
+    }
+    
+    func downscaled(toMaxDimension maxDimension: CGFloat) -> UIImage {
+        let size = self.size
+        let maxDim = max(size.width, size.height)
+        if maxDim <= maxDimension {
+            return self
+        }
+        
+        let scale = maxDimension / maxDim
+        let newSize = CGSize(width: size.width * scale, height: size.height * scale)
+        
+        let format = UIGraphicsImageRendererFormat.default()
+        format.scale = 1.0 // Use 1.0 scale to keep exact pixel dimensions
+        let renderer = UIGraphicsImageRenderer(size: newSize, format: format)
+        
+        return renderer.image { _ in
+            self.draw(in: CGRect(origin: .zero, size: newSize))
         }
     }
 }
@@ -653,7 +752,7 @@ extension UIImage {
 // MARK: - MagnifierView
 
 class MagnifierView: UIView {
-    var viewToMagnify: UIView?
+    var snapshotImage: UIImage?
     var touchPoint: CGPoint = .zero {
         didSet {
             setNeedsDisplay()
@@ -674,23 +773,17 @@ class MagnifierView: UIView {
     }
     
     override func draw(_ rect: CGRect) {
-        guard let context = UIGraphicsGetCurrentContext(), let view = viewToMagnify else { return }
+        guard let context = UIGraphicsGetCurrentContext(), let image = snapshotImage else { return }
         
         // Circular clipping
         let path = UIBezierPath(ovalIn: rect)
         path.addClip()
         
-        // Temporarily hide magnifier view to avoid rendering itself
-        let wasHidden = self.isHidden
-        self.isHidden = true
-        
         context.translateBy(x: rect.width / 2, y: rect.height / 2)
         context.scaleBy(x: 1.5, y: 1.5)
         context.translateBy(x: -touchPoint.x, y: -touchPoint.y)
         
-        view.layer.render(in: context)
-        
-        self.isHidden = wasHidden
+        image.draw(at: .zero)
         
         // Draw border ring
         UIColor.white.setStroke()

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/CunningDocumentCropperViewController.swift
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/CunningDocumentCropperViewController.swift
@@ -1,0 +1,450 @@
+import UIKit
+import Vision
+import CoreImage
+
+protocol CunningDocumentCropperDelegate: AnyObject {
+    func didFinishCropping(croppedImages: [UIImage])
+    func didCancelCropping()
+}
+
+class CunningDocumentCropperViewController: UIViewController {
+    weak var delegate: CunningDocumentCropperDelegate?
+    
+    private var images: [UIImage] = []
+    private var croppedImages: [UIImage] = []
+    private var currentIndex = 0
+    
+    private let imageView = UIImageView()
+    private let overlayView = CroppingOverlayView()
+    private let topBar = UIView()
+    private let bottomBar = UIView()
+    
+    private let titleLabel = UILabel()
+    private let cancelButton = UIButton(type: .system)
+    private let doneButton = UIButton(type: .system)
+    
+    private var hasSetupPoints = false
+    private let localize: (String, String) -> String
+    
+    // Normalized coordinates (origin at bottom-left)
+    private var normTopLeft = CGPoint(x: 0.15, y: 0.85)
+    private var normTopRight = CGPoint(x: 0.85, y: 0.85)
+    private var normBottomLeft = CGPoint(x: 0.15, y: 0.15)
+    private var normBottomRight = CGPoint(x: 0.85, y: 0.15)
+    
+    init(images: [UIImage], localize: @escaping (String, String) -> String) {
+        self.localize = localize
+        super.init(nibName: nil, bundle: nil)
+        // Normalize orientations of all images first
+        self.images = images.map { $0.fixedOrientation() }
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .black
+        setupViews()
+        setupConstraints()
+    }
+    
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        
+        let frame = getContentFrame()
+        overlayView.contentFrame = frame
+        
+        if !hasSetupPoints && currentIndex < images.count {
+            hasSetupPoints = true
+            detectAndSetupPoints()
+        } else {
+            updateHandlesToMatchNormalizedPoints()
+        }
+    }
+    
+    private func setupViews() {
+        // Image View configuration
+        imageView.contentMode = .scaleAspectFit
+        imageView.clipsToBounds = true
+        view.addSubview(imageView)
+        
+        // Overlay View configuration
+        overlayView.onPointsChanged = { [weak self] in
+            guard let self = self else { return }
+            let frame = self.getContentFrame()
+            self.normTopLeft = self.overlayView.normalizedPoint(fromView: self.overlayView.topLeft, contentFrame: frame)
+            self.normTopRight = self.overlayView.normalizedPoint(fromView: self.overlayView.topRight, contentFrame: frame)
+            self.normBottomLeft = self.overlayView.normalizedPoint(fromView: self.overlayView.bottomLeft, contentFrame: frame)
+            self.normBottomRight = self.overlayView.normalizedPoint(fromView: self.overlayView.bottomRight, contentFrame: frame)
+        }
+        view.addSubview(overlayView)
+        
+        // Top Bar configuration
+        topBar.backgroundColor = UIColor.black.withAlphaComponent(0.6)
+        view.addSubview(topBar)
+        
+        titleLabel.textColor = .white
+        titleLabel.font = UIFont.systemFont(ofSize: 18, weight: .bold)
+        titleLabel.textAlignment = .center
+        topBar.addSubview(titleLabel)
+        
+        // Bottom Bar configuration
+        bottomBar.backgroundColor = UIColor.black.withAlphaComponent(0.6)
+        view.addSubview(bottomBar)
+        
+        cancelButton.setTitle(localize("cunning_document_scanner_cancel", "Cancel"), for: .normal)
+        cancelButton.setTitleColor(.systemRed, for: .normal)
+        cancelButton.titleLabel?.font = UIFont.systemFont(ofSize: 16, weight: .medium)
+        cancelButton.addTarget(self, action: #selector(handleCancel), for: .touchUpInside)
+        bottomBar.addSubview(cancelButton)
+        
+        doneButton.setTitle(localize("cunning_document_scanner_next", "Next"), for: .normal)
+        doneButton.setTitleColor(.systemBlue, for: .normal)
+        doneButton.titleLabel?.font = UIFont.systemFont(ofSize: 16, weight: .bold)
+        doneButton.addTarget(self, action: #selector(handleDone), for: .touchUpInside)
+        bottomBar.addSubview(doneButton)
+        
+        loadCurrentImage()
+    }
+    
+    private func setupConstraints() {
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        overlayView.translatesAutoresizingMaskIntoConstraints = false
+        topBar.translatesAutoresizingMaskIntoConstraints = false
+        bottomBar.translatesAutoresizingMaskIntoConstraints = false
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        cancelButton.translatesAutoresizingMaskIntoConstraints = false
+        doneButton.translatesAutoresizingMaskIntoConstraints = false
+        
+        NSLayoutConstraint.activate([
+            // Top Bar
+            topBar.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            topBar.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            topBar.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            topBar.heightAnchor.constraint(equalToConstant: 50),
+            
+            titleLabel.centerXAnchor.constraint(equalTo: topBar.centerXAnchor),
+            titleLabel.centerYAnchor.constraint(equalTo: topBar.centerYAnchor),
+            
+            // Bottom Bar
+            bottomBar.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+            bottomBar.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            bottomBar.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            bottomBar.heightAnchor.constraint(equalToConstant: 60),
+            
+            cancelButton.leadingAnchor.constraint(equalTo: bottomBar.leadingAnchor, constant: 20),
+            cancelButton.centerYAnchor.constraint(equalTo: bottomBar.centerYAnchor),
+            
+            doneButton.trailingAnchor.constraint(equalTo: bottomBar.trailingAnchor, constant: -20),
+            doneButton.centerYAnchor.constraint(equalTo: bottomBar.centerYAnchor),
+            
+            // Image View (fills space between top and bottom bar)
+            imageView.topAnchor.constraint(equalTo: topBar.bottomAnchor),
+            imageView.bottomAnchor.constraint(equalTo: bottomBar.topAnchor),
+            imageView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            imageView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            
+            // Overlay View covers image view exactly
+            overlayView.topAnchor.constraint(equalTo: imageView.topAnchor),
+            overlayView.bottomAnchor.constraint(equalTo: imageView.bottomAnchor),
+            overlayView.leadingAnchor.constraint(equalTo: imageView.leadingAnchor),
+            overlayView.trailingAnchor.constraint(equalTo: imageView.trailingAnchor)
+        ])
+    }
+    
+    private func loadCurrentImage() {
+        guard currentIndex < images.count else { return }
+        
+        let currentImage = images[currentIndex]
+        imageView.image = currentImage
+        
+        // Update Title and Done Button Label
+        let pageNum = currentIndex + 1
+        let titleFormat = localize("cunning_document_scanner_crop_title", "Crop Page %d of %d")
+        titleLabel.text = String(format: titleFormat, pageNum, images.count)
+        
+        let doneTitle = (currentIndex == images.count - 1)
+            ? localize("cunning_document_scanner_done", "Done")
+            : localize("cunning_document_scanner_next", "Next")
+        doneButton.setTitle(doneTitle, for: .normal)
+        
+        // Reset flags for the new image detection
+        hasSetupPoints = false
+        view.setNeedsLayout()
+    }
+    
+    private func detectAndSetupPoints() {
+        guard currentIndex < images.count else { return }
+        let currentImage = images[currentIndex]
+        
+        // Set default points initially
+        self.normTopLeft = CGPoint(x: 0.15, y: 0.85)
+        self.normTopRight = CGPoint(x: 0.85, y: 0.85)
+        self.normBottomLeft = CGPoint(x: 0.15, y: 0.15)
+        self.normBottomRight = CGPoint(x: 0.85, y: 0.15)
+        
+        self.updateHandlesToMatchNormalizedPoints()
+        
+        // Run vision detection asynchronously
+        guard let cgImage = currentImage.cgImage else { return }
+        let request = VNDetectDocumentSegmentationRequest { [weak self] request, error in
+            guard let self = self else { return }
+            guard error == nil,
+                  let results = request.results as? [VNRectangleObservation],
+                  let firstResult = results.first else {
+                return // Use defaults
+            }
+            
+            DispatchQueue.main.async {
+                // Verify we are still on the same image
+                self.normTopLeft = firstResult.topLeft
+                self.normTopRight = firstResult.topRight
+                self.normBottomLeft = firstResult.bottomLeft
+                self.normBottomRight = firstResult.bottomRight
+                self.updateHandlesToMatchNormalizedPoints()
+            }
+        }
+        
+        let handler = VNImageRequestHandler(cgImage: cgImage, options: [:])
+        DispatchQueue.global(qos: .userInitiated).async {
+            try? handler.perform([request])
+        }
+    }
+    
+    private func updateHandlesToMatchNormalizedPoints() {
+        let frame = getContentFrame()
+        overlayView.topLeft = overlayView.viewPoint(fromNormalized: normTopLeft, contentFrame: frame)
+        overlayView.topRight = overlayView.viewPoint(fromNormalized: normTopRight, contentFrame: frame)
+        overlayView.bottomLeft = overlayView.viewPoint(fromNormalized: normBottomLeft, contentFrame: frame)
+        overlayView.bottomRight = overlayView.viewPoint(fromNormalized: normBottomRight, contentFrame: frame)
+        overlayView.updateHandlePositions()
+    }
+    
+    private func getContentFrame() -> CGRect {
+        guard let image = imageView.image else { return .zero }
+        let imgSize = image.size
+        let viewSize = imageView.bounds.size
+        
+        guard imgSize.width > 0 && imgSize.height > 0 && viewSize.width > 0 && viewSize.height > 0 else {
+            return .zero
+        }
+        
+        let wRatio = viewSize.width / imgSize.width
+        let hRatio = viewSize.height / imgSize.height
+        let scale = min(wRatio, hRatio)
+        
+        let contentW = imgSize.width * scale
+        let contentH = imgSize.height * scale
+        let x = (viewSize.width - contentW) / 2.0
+        let y = (viewSize.height - contentH) / 2.0
+        
+        return CGRect(x: x, y: y, width: contentW, height: contentH)
+    }
+    
+    @objc private func handleCancel() {
+        delegate?.didCancelCropping()
+    }
+    
+    @objc private func handleDone() {
+        guard currentIndex < images.count else { return }
+        
+        // Show spinner / block buttons to prevent double-tap
+        cancelButton.isEnabled = false
+        doneButton.isEnabled = false
+        
+        let currentImage = images[currentIndex]
+        
+        // Crop the current image on a background thread
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            guard let self = self else { return }
+            
+            let cropped = self.cropImage(
+                image: currentImage,
+                topLeft: self.normTopLeft,
+                topRight: self.normTopRight,
+                bottomLeft: self.normBottomLeft,
+                bottomRight: self.normBottomRight
+            )
+            
+            DispatchQueue.main.async {
+                self.cancelButton.isEnabled = true
+                self.doneButton.isEnabled = true
+                
+                if let cropped = cropped {
+                    self.croppedImages.append(cropped)
+                } else {
+                    // Fallback to original image if cropping failed
+                    self.croppedImages.append(currentImage)
+                }
+                
+                self.currentIndex += 1
+                if self.currentIndex < self.images.count {
+                    self.loadCurrentImage()
+                } else {
+                    self.delegate?.didFinishCropping(croppedImages: self.croppedImages)
+                }
+            }
+        }
+    }
+    
+    private func cropImage(image: UIImage, topLeft: CGPoint, topRight: CGPoint, bottomLeft: CGPoint, bottomRight: CGPoint) -> UIImage? {
+        guard let ciImage = CIImage(image: image) else { return nil }
+        
+        let w = image.size.width
+        let h = image.size.height
+        
+        let tl = CIVector(x: topLeft.x * w, y: topLeft.y * h)
+        let tr = CIVector(x: topRight.x * w, y: topRight.y * h)
+        let bl = CIVector(x: bottomLeft.x * w, y: bottomLeft.y * h)
+        let br = CIVector(x: bottomRight.x * w, y: bottomRight.y * h)
+        
+        guard let filter = CIFilter(name: "CIPerspectiveCorrection") else { return nil }
+        filter.setValue(ciImage, forKey: kCIInputImageKey)
+        filter.setValue(tl, forKey: "inputTopLeft")
+        filter.setValue(tr, forKey: "inputTopRight")
+        filter.setValue(bl, forKey: "inputBottomLeft")
+        filter.setValue(br, forKey: "inputBottomRight")
+        
+        guard let outputImage = filter.outputImage else { return nil }
+        
+        let context = CIContext(options: nil)
+        guard let cgImage = context.createCGImage(outputImage, from: outputImage.extent) else { return nil }
+        
+        return UIImage(cgImage: cgImage)
+    }
+}
+
+// MARK: - CroppingOverlayView
+
+class CroppingOverlayView: UIView {
+    var topLeft = CGPoint.zero
+    var topRight = CGPoint.zero
+    var bottomLeft = CGPoint.zero
+    var bottomRight = CGPoint.zero
+    
+    var contentFrame = CGRect.zero
+    var onPointsChanged: (() -> Void)?
+    
+    private var handles: [UIView] = []
+    private let handleSize: CGFloat = 34
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        backgroundColor = .clear
+        setupHandles()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        backgroundColor = .clear
+        setupHandles()
+    }
+    
+    private func setupHandles() {
+        for i in 0..<4 {
+            let handle = UIView()
+            handle.backgroundColor = UIColor.systemBlue.withAlphaComponent(0.8)
+            handle.layer.cornerRadius = handleSize / 2
+            handle.layer.borderWidth = 3
+            handle.layer.borderColor = UIColor.white.cgColor
+            handle.tag = i
+            
+            let pan = UIPanGestureRecognizer(target: self, action: #selector(handlePan(_:)))
+            handle.addGestureRecognizer(pan)
+            addSubview(handle)
+            handles.append(handle)
+        }
+    }
+    
+    func updateHandlePositions() {
+        guard handles.count == 4 else { return }
+        handles[0].center = topLeft
+        handles[1].center = topRight
+        handles[2].center = bottomLeft
+        handles[3].center = bottomRight
+        setNeedsDisplay()
+    }
+    
+    @objc private func handlePan(_ gesture: UIPanGestureRecognizer) {
+        guard let handle = gesture.view else { return }
+        let translation = gesture.translation(in: self)
+        var newCenter = CGPoint(x: handle.center.x + translation.x, y: handle.center.y + translation.y)
+        
+        // Restrict drag inside the image content frame (if set)
+        if contentFrame != .zero {
+            newCenter.x = max(contentFrame.minX, min(contentFrame.maxX, newCenter.x))
+            newCenter.y = max(contentFrame.minY, min(contentFrame.maxY, newCenter.y))
+        } else {
+            newCenter.x = max(0, min(bounds.width, newCenter.x))
+            newCenter.y = max(0, min(bounds.height, newCenter.y))
+        }
+        
+        handle.center = newCenter
+        gesture.setTranslation(.zero, in: self)
+        
+        switch handle.tag {
+        case 0: topLeft = newCenter
+        case 1: topRight = newCenter
+        case 2: bottomLeft = newCenter
+        case 3: bottomRight = newCenter
+        default: break
+        }
+        
+        onPointsChanged?()
+        setNeedsDisplay()
+    }
+    
+    override func draw(_ rect: CGRect) {
+        guard topLeft != .zero || topRight != .zero || bottomLeft != .zero || bottomRight != .zero else {
+            return
+        }
+        
+        let path = UIBezierPath()
+        path.move(to: topLeft)
+        path.addLine(to: topRight)
+        path.addLine(to: bottomRight)
+        path.addLine(to: bottomLeft)
+        path.close()
+        
+        // Draw fill area
+        UIColor.systemBlue.withAlphaComponent(0.25).setFill()
+        path.fill()
+        
+        // Draw crop frame lines
+        UIColor.systemBlue.setStroke()
+        path.lineWidth = 3
+        path.stroke()
+    }
+    
+    // Convert points coordinate mappings
+    func viewPoint(fromNormalized point: CGPoint, contentFrame: CGRect) -> CGPoint {
+        guard contentFrame.width > 0 && contentFrame.height > 0 else { return .zero }
+        let vx = contentFrame.origin.x + point.x * contentFrame.size.width
+        let vy = contentFrame.origin.y + (1.0 - point.y) * contentFrame.size.height
+        return CGPoint(x: vx, y: vy)
+    }
+    
+    func normalizedPoint(fromView point: CGPoint, contentFrame: CGRect) -> CGPoint {
+        guard contentFrame.width > 0 && contentFrame.height > 0 else { return .zero }
+        let px = (point.x - contentFrame.origin.x) / contentFrame.size.width
+        let py = 1.0 - (point.y - contentFrame.origin.y) / contentFrame.size.height
+        return CGPoint(x: max(0.0, min(1.0, px)), y: max(0.0, min(1.0, py)))
+    }
+}
+
+// MARK: - UIImage Extension (Fix Orientation)
+
+extension UIImage {
+    func fixedOrientation() -> UIImage {
+        if imageOrientation == .up { return self }
+        
+        UIGraphicsBeginImageContextWithOptions(size, false, scale)
+        draw(in: CGRect(origin: .zero, size: size))
+        let normalizedImage = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+        
+        return normalizedImage ?? self
+    }
+}

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/CunningDocumentCropperViewController.swift
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/CunningDocumentCropperViewController.swift
@@ -23,9 +23,19 @@ class CunningDocumentCropperViewController: UIViewController {
     private let cancelButton = UIButton(type: .system)
     private let doneButton = UIButton(type: .system)
     private let rotateButton = UIButton(type: .system)
+    private let backButton = UIButton(type: .system)
     
     private let activityIndicator = UIActivityIndicatorView(style: .large)
     private let ciContext = CIContext(options: nil)
+    
+    private struct PageCoordinates {
+        let topLeft: CGPoint
+        let topRight: CGPoint
+        let bottomLeft: CGPoint
+        let bottomRight: CGPoint
+    }
+    
+    private var savedCoordinates: [PageCoordinates?] = []
     
     private var hasSetupPoints = false
     private var hasUserModifiedPoints = false
@@ -42,6 +52,7 @@ class CunningDocumentCropperViewController: UIViewController {
         self.localize = localize
         self.images = images
         super.init(nibName: nil, bundle: nil)
+        self.savedCoordinates = Array(repeating: nil, count: images.count)
     }
     
     override var preferredStatusBarStyle: UIStatusBarStyle {
@@ -132,6 +143,15 @@ class CunningDocumentCropperViewController: UIViewController {
         rotateButton.addTarget(self, action: #selector(handleRotate), for: .touchUpInside)
         bottomBar.addSubview(rotateButton)
         
+        // Back Button configuration (top-left)
+        backButton.setImage(UIImage(systemName: "chevron.left", withConfiguration: config), for: .normal)
+        backButton.tintColor = .white
+        backButton.backgroundColor = UIColor.white.withAlphaComponent(0.15)
+        backButton.layer.cornerRadius = 18
+        backButton.clipsToBounds = true
+        backButton.addTarget(self, action: #selector(handleBack), for: .touchUpInside)
+        topBar.addSubview(backButton)
+        
         loadCurrentImage()
     }
     
@@ -144,9 +164,16 @@ class CunningDocumentCropperViewController: UIViewController {
         cancelButton.translatesAutoresizingMaskIntoConstraints = false
         doneButton.translatesAutoresizingMaskIntoConstraints = false
         rotateButton.translatesAutoresizingMaskIntoConstraints = false
+        backButton.translatesAutoresizingMaskIntoConstraints = false
         activityIndicator.translatesAutoresizingMaskIntoConstraints = false
         
         NSLayoutConstraint.activate([
+            // Back Button (Top Bar left)
+            backButton.leadingAnchor.constraint(equalTo: topBar.leadingAnchor, constant: 15),
+            backButton.centerYAnchor.constraint(equalTo: topBar.centerYAnchor),
+            backButton.widthAnchor.constraint(equalToConstant: 36),
+            backButton.heightAnchor.constraint(equalToConstant: 36),
+            
             // Activity Indicator
             activityIndicator.centerXAnchor.constraint(equalTo: view.centerXAnchor),
             activityIndicator.centerYAnchor.constraint(equalTo: view.centerYAnchor),
@@ -215,9 +242,21 @@ class CunningDocumentCropperViewController: UIViewController {
         doneButton.tintColor = .white
         doneButton.backgroundColor = .systemBlue
         
-        // Reset flags for the new image detection
-        hasSetupPoints = false
-        hasUserModifiedPoints = false
+        // Show/hide back button based on page index
+        backButton.isHidden = (currentIndex == 0)
+        
+        // Restore coordinates if previously saved, otherwise run auto-detection
+        if let saved = savedCoordinates[currentIndex] {
+            self.normTopLeft = saved.topLeft
+            self.normTopRight = saved.topRight
+            self.normBottomLeft = saved.bottomLeft
+            self.normBottomRight = saved.bottomRight
+            self.hasSetupPoints = true
+            self.hasUserModifiedPoints = true
+        } else {
+            self.hasSetupPoints = false
+            self.hasUserModifiedPoints = false
+        }
         view.setNeedsLayout()
     }
     
@@ -301,10 +340,19 @@ class CunningDocumentCropperViewController: UIViewController {
         guard currentIndex < images.count else { return }
         guard let currentImage = self.currentNormalizedImage else { return }
         
+        // Save current coordinates
+        self.savedCoordinates[currentIndex] = PageCoordinates(
+            topLeft: self.normTopLeft,
+            topRight: self.normTopRight,
+            bottomLeft: self.normBottomLeft,
+            bottomRight: self.normBottomRight
+        )
+        
         // Show spinner / block buttons to prevent double-tap
         cancelButton.isEnabled = false
         doneButton.isEnabled = false
         rotateButton.isEnabled = false
+        backButton.isEnabled = false
         activityIndicator.startAnimating()
         
         // Crop the current image on a background thread
@@ -323,6 +371,7 @@ class CunningDocumentCropperViewController: UIViewController {
                 self.cancelButton.isEnabled = true
                 self.doneButton.isEnabled = true
                 self.rotateButton.isEnabled = true
+                self.backButton.isEnabled = true
                 self.activityIndicator.stopAnimating()
                 
                 if let cropped = cropped {
@@ -351,10 +400,25 @@ class CunningDocumentCropperViewController: UIViewController {
             self.currentNormalizedImage = rotated
             self.imageView.image = rotated
             
+            // Clear any saved coordinates for this page to force re-detection on new orientation
+            self.savedCoordinates[currentIndex] = nil
+            
             // Reset flags to force handle calculation on rotated dimensions
             hasSetupPoints = false
             view.setNeedsLayout()
         }
+    }
+    
+    @objc private func handleBack() {
+        guard currentIndex > 0 else { return }
+        
+        // Remove the last cropped image
+        if !croppedImages.isEmpty {
+            croppedImages.removeLast()
+        }
+        
+        currentIndex -= 1
+        loadCurrentImage()
     }
     
     private func cropImage(image: UIImage, topLeft: CGPoint, topRight: CGPoint, bottomLeft: CGPoint, bottomRight: CGPoint) -> UIImage? {

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/CunningDocumentScannerPlugin.swift
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/CunningDocumentScannerPlugin.swift
@@ -202,8 +202,10 @@ public class CunningDocumentScannerPlugin: NSObject, FlutterPlugin, VNDocumentCa
             return
         }
         
+        let downscaledImage = image.downscaled(toMaxDimension: 2048)
+        
         picker.dismiss(animated: true) {
-            let cropper = CunningDocumentCropperViewController(images: [image]) { [weak self] key, defaultValue in
+            let cropper = CunningDocumentCropperViewController(images: [downscaledImage]) { [weak self] key, defaultValue in
                 return self?.getLocalizedOption(key, defaultValue: defaultValue) ?? defaultValue
             }
             cropper.delegate = self
@@ -239,7 +241,8 @@ extension CunningDocumentScannerPlugin: PHPickerViewControllerDelegate {
                 dispatchGroup.enter()
                 result.itemProvider.loadObject(ofClass: UIImage.self) { (object, error) in
                     if let image = object as? UIImage {
-                        images[index] = image
+                        // Downscale immediately to prevent memory spikes in concurrent loads
+                        images[index] = image.downscaled(toMaxDimension: 2048)
                     }
                     dispatchGroup.leave()
                 }

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/CunningDocumentScannerPlugin.swift
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/CunningDocumentScannerPlugin.swift
@@ -6,11 +6,20 @@ import PDFKit
 import Photos
 import PhotosUI
 
+/// Main iOS plugin class for cunning_document_scanner.
+/// Handles Flutter MethodChannel calls to launch camera or photo gallery scanning flows.
 public class CunningDocumentScannerPlugin: NSObject, FlutterPlugin, VNDocumentCameraViewControllerDelegate, UIImagePickerControllerDelegate, UINavigationControllerDelegate {
+    
+    /// The Flutter channel result callback pointer to return document paths to Dart/Flutter.
     var resultChannel: FlutterResult?
+    
+    /// The native VNDocumentCameraViewController presenting instance.
     var presentingController: VNDocumentCameraViewController?
+    
+    /// The options passed from the Dart/Flutter side.
     var scannerOptions = CunningScannerOptions()
 
+    /// Resolves the current visible or root UIViewController on the key window.
     var rootViewController: UIViewController? {
         let keyWindow = UIApplication.shared.connectedScenes
             .compactMap { $0 as? UIWindowScene }
@@ -19,12 +28,14 @@ public class CunningDocumentScannerPlugin: NSObject, FlutterPlugin, VNDocumentCa
         return keyWindow?.rootViewController
     }
 
+    /// Registers the plugin instance with the Flutter registrar.
     public static func register(with registrar: FlutterPluginRegistrar) {
         let channel = FlutterMethodChannel(name: "cunning_document_scanner", binaryMessenger: registrar.messenger())
         let instance = CunningDocumentScannerPlugin()
         registrar.addMethodCallDelegate(instance, channel: channel)
     }
 
+    /// Handles incoming FlutterMethodCalls. Specifically listens to the "getPictures" method.
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         guard call.method == "getPictures" else {
             result(FlutterMethodNotImplemented)
@@ -77,6 +88,7 @@ public class CunningDocumentScannerPlugin: NSObject, FlutterPlugin, VNDocumentCa
         }
     }
 
+    /// Launches the native system document camera (VNDocumentCameraViewController).
     func openCamera(from presentedVC: UIViewController?) {
         if VNDocumentCameraViewController.isSupported {
             presentingController = VNDocumentCameraViewController()
@@ -87,6 +99,7 @@ public class CunningDocumentScannerPlugin: NSObject, FlutterPlugin, VNDocumentCa
         }
     }
 
+    /// Launches the photo picker (PHPickerViewController on iOS 14+, fallback to UIImagePickerController).
     func openGallery(from presentedVC: UIViewController?) {
         if #available(iOS 14.0, *) {
             var configuration = PHPickerConfiguration()
@@ -104,11 +117,13 @@ public class CunningDocumentScannerPlugin: NSObject, FlutterPlugin, VNDocumentCa
         }
     }
 
+    /// Helper to retrieve the app's documents directory URL.
     func getDocumentsDirectory() -> URL {
         let paths = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)
         return paths[0]
     }
 
+    /// Helper to fetch localized string translations for keys, falling back to a default value.
     func getLocalizedOption(_ key: String, defaultValue: String) -> String {
         let mainBundleValue = Bundle.main.localizedString(forKey: key, value: nil, table: nil)
         if mainBundleValue != key {
@@ -133,6 +148,7 @@ public class CunningDocumentScannerPlugin: NSObject, FlutterPlugin, VNDocumentCa
         return resolvedBundle.localizedString(forKey: key, value: defaultValue, table: nil)
     }
 
+    /// Writes scanned or cropped images to local files (or compiles them to a single PDF) and returns paths to Flutter.
     func processSelectedImages(_ images: [UIImage]) {
         let tempDirPath = getDocumentsDirectory()
         let currentDateTime = Date()
@@ -173,6 +189,7 @@ public class CunningDocumentScannerPlugin: NSObject, FlutterPlugin, VNDocumentCa
 
     // MARK: - VNDocumentCameraViewControllerDelegate
 
+    /// Delegate callback for camera scans. Receives pages and processes them directly.
     public func documentCameraViewController(_ controller: VNDocumentCameraViewController, didFinishWith scan: VNDocumentCameraScan) {
         var images: [UIImage] = []
         for i in 0 ..< scan.pageCount {
@@ -182,11 +199,13 @@ public class CunningDocumentScannerPlugin: NSObject, FlutterPlugin, VNDocumentCa
         presentingController?.dismiss(animated: true)
     }
 
+    /// Delegate callback for cancelled camera scans.
     public func documentCameraViewControllerDidCancel(_ controller: VNDocumentCameraViewController) {
         resultChannel?(nil)
         presentingController?.dismiss(animated: true)
     }
 
+    /// Delegate callback for camera scan failures.
     public func documentCameraViewController(_ controller: VNDocumentCameraViewController, didFailWithError error: Error) {
         resultChannel?(FlutterError(code: "ERROR", message: error.localizedDescription, details: nil))
         presentingController?.dismiss(animated: true)
@@ -194,6 +213,7 @@ public class CunningDocumentScannerPlugin: NSObject, FlutterPlugin, VNDocumentCa
 
     // MARK: - UIImagePickerControllerDelegate
 
+    /// Delegate callback for picking media (legacy UIImagePickerController).
     public func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
         guard let image = info[.originalImage] as? UIImage else {
             picker.dismiss(animated: true) {
@@ -214,6 +234,7 @@ public class CunningDocumentScannerPlugin: NSObject, FlutterPlugin, VNDocumentCa
         }
     }
 
+    /// Delegate callback for legacy picker cancellations.
     public func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
         picker.dismiss(animated: true) {
             self.resultChannel?(nil)
@@ -225,6 +246,8 @@ public class CunningDocumentScannerPlugin: NSObject, FlutterPlugin, VNDocumentCa
 
 @available(iOS 14.0, *)
 extension CunningDocumentScannerPlugin: PHPickerViewControllerDelegate {
+    
+    /// Delegate callback for picking media with the modern PHPickerViewController.
     public func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
         if results.isEmpty {
             picker.dismiss(animated: true) {
@@ -278,12 +301,15 @@ extension CunningDocumentScannerPlugin: PHPickerViewControllerDelegate {
 // MARK: - CunningDocumentCropperDelegate
 
 extension CunningDocumentScannerPlugin: CunningDocumentCropperDelegate {
+    
+    /// Handles completion of cropping flow. Passes cropped results to the file output processor.
     func didFinishCropping(croppedImages: [UIImage]) {
         rootViewController?.dismiss(animated: true) {
             self.processSelectedImages(croppedImages)
         }
     }
     
+    /// Handles cancel/abort events from the cropper view controller.
     func didCancelCropping() {
         rootViewController?.dismiss(animated: true) {
             self.resultChannel?(nil)

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/CunningDocumentScannerPlugin.swift
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/CunningDocumentScannerPlugin.swift
@@ -195,19 +195,27 @@ public class CunningDocumentScannerPlugin: NSObject, FlutterPlugin, VNDocumentCa
     // MARK: - UIImagePickerControllerDelegate
 
     public func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
-        picker.dismiss(animated: true)
-        
         guard let image = info[.originalImage] as? UIImage else {
-            resultChannel?(nil)
+            picker.dismiss(animated: true) {
+                self.resultChannel?(nil)
+            }
             return
         }
         
-        processSelectedImages([image])
+        picker.dismiss(animated: true) {
+            let cropper = CunningDocumentCropperViewController(images: [image]) { [weak self] key, defaultValue in
+                return self?.getLocalizedOption(key, defaultValue: defaultValue) ?? defaultValue
+            }
+            cropper.delegate = self
+            cropper.modalPresentationStyle = .fullScreen
+            self.rootViewController?.present(cropper, animated: true)
+        }
     }
 
     public func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
-        picker.dismiss(animated: true)
-        resultChannel?(nil)
+        picker.dismiss(animated: true) {
+            self.resultChannel?(nil)
+        }
     }
 }
 
@@ -216,10 +224,10 @@ public class CunningDocumentScannerPlugin: NSObject, FlutterPlugin, VNDocumentCa
 @available(iOS 14.0, *)
 extension CunningDocumentScannerPlugin: PHPickerViewControllerDelegate {
     public func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
-        picker.dismiss(animated: true)
-        
         if results.isEmpty {
-            resultChannel?(nil)
+            picker.dismiss(animated: true) {
+                self.resultChannel?(nil)
+            }
             return
         }
         
@@ -241,10 +249,35 @@ extension CunningDocumentScannerPlugin: PHPickerViewControllerDelegate {
         dispatchGroup.notify(queue: .main) {
             let validImages = images.filter { $0.size.width > 0 }
             if validImages.isEmpty {
-                self.resultChannel?(nil)
+                picker.dismiss(animated: true) {
+                    self.resultChannel?(nil)
+                }
             } else {
-                self.processSelectedImages(validImages)
+                picker.dismiss(animated: true) {
+                    let cropper = CunningDocumentCropperViewController(images: validImages) { [weak self] key, defaultValue in
+                        return self?.getLocalizedOption(key, defaultValue: defaultValue) ?? defaultValue
+                    }
+                    cropper.delegate = self
+                    cropper.modalPresentationStyle = .fullScreen
+                    self.rootViewController?.present(cropper, animated: true)
+                }
             }
+        }
+    }
+}
+
+// MARK: - CunningDocumentCropperDelegate
+
+extension CunningDocumentScannerPlugin: CunningDocumentCropperDelegate {
+    func didFinishCropping(croppedImages: [UIImage]) {
+        rootViewController?.dismiss(animated: true) {
+            self.processSelectedImages(croppedImages)
+        }
+    }
+    
+    func didCancelCropping() {
+        rootViewController?.dismiss(animated: true) {
+            self.resultChannel?(nil)
         }
     }
 }

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/CunningDocumentScannerPlugin.swift
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/CunningDocumentScannerPlugin.swift
@@ -241,10 +241,16 @@ extension CunningDocumentScannerPlugin: PHPickerViewControllerDelegate {
                 dispatchGroup.enter()
                 result.itemProvider.loadObject(ofClass: UIImage.self) { (object, error) in
                     if let image = object as? UIImage {
-                        // Downscale immediately to prevent memory spikes in concurrent loads
-                        images[index] = image.downscaled(toMaxDimension: 2048)
+                        let downscaled = image.downscaled(toMaxDimension: 2048)
+                        DispatchQueue.main.async {
+                            images[index] = downscaled
+                            dispatchGroup.leave()
+                        }
+                    } else {
+                        DispatchQueue.main.async {
+                            dispatchGroup.leave()
+                        }
                     }
-                    dispatchGroup.leave()
                 }
             }
         }

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/CunningScannerOptions.swift
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/CunningScannerOptions.swift
@@ -1,23 +1,36 @@
 import Foundation
 
+/// Defines the output image format configurations.
 enum CunningScannerImageFormat: String {
     case jpg
     case png
 }
 
+/// Defines the source to scan documents from.
 enum CunningScannerSource: String {
     case camera
     case gallery
     case cameraAndGallery = "camera_and_gallery"
 }
 
+/// A structure to hold document scanner configuration parameters.
 struct CunningScannerOptions {
+    /// Target image format (PNG or JPG).
     let imageFormat: CunningScannerImageFormat
+    
+    /// The compression quality from 0.0 to 1.0 (only applicable for JPG output).
     let jpgCompressionQuality: Double
+    
+    /// If true, outputs scanned images combined into a single PDF document.
     let asPdf: Bool
+    
+    /// Deprecated property indicating whether gallery selection is permitted.
     let isGalleryImportAllowed: Bool
+    
+    /// The target source for scanning (camera, gallery, or both).
     let scannerSource: CunningScannerSource
 
+    /// Creates scanner options with default settings.
     init() {
         self.imageFormat = .png
         self.jpgCompressionQuality = 1.0
@@ -26,6 +39,7 @@ struct CunningScannerOptions {
         self.scannerSource = .camera
     }
 
+    /// Creates scanner options with specified settings.
     init(imageFormat: CunningScannerImageFormat, jpgCompressionQuality: Double, asPdf: Bool, isGalleryImportAllowed: Bool, scannerSource: CunningScannerSource) {
         self.imageFormat = imageFormat
         self.jpgCompressionQuality = jpgCompressionQuality
@@ -34,6 +48,7 @@ struct CunningScannerOptions {
         self.scannerSource = scannerSource
     }
 
+    /// Factory method to build a CunningScannerOptions object from incoming Flutter MethodChannel arguments.
     static func fromArguments(args: Any?) -> CunningScannerOptions {
         guard let arguments = args as? [String: Any] else {
             return CunningScannerOptions()

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/MagnifierView.swift
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/MagnifierView.swift
@@ -1,0 +1,63 @@
+import UIKit
+
+/// A circular zoom lens view that provides pixel-perfect positioning of cropping handles.
+/// It renders a magnified segment of the background image centered over the user's touch point.
+class MagnifierView: UIView {
+    
+    /// The cached snapshot image of the parent view controller's main view.
+    var snapshotImage: UIImage?
+    
+    /// The current touch coordinate inside the parent view space to magnify.
+    var touchPoint: CGPoint = .zero {
+        didSet {
+            setNeedsDisplay()
+        }
+    }
+    
+    /// Initializes a new magnifier view with a default drop shadow style.
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        backgroundColor = .clear
+        layer.shadowColor = UIColor.black.cgColor
+        layer.shadowOpacity = 0.5
+        layer.shadowOffset = CGSize(width: 0, height: 3)
+        layer.shadowRadius = 4
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    /// Renders the magnified circular segment of the snapshot image, a border ring, and a center crosshair.
+    override func draw(_ rect: CGRect) {
+        guard let context = UIGraphicsGetCurrentContext(), let image = snapshotImage else { return }
+        
+        // Circular clipping
+        let path = UIBezierPath(ovalIn: rect)
+        path.addClip()
+        
+        context.translateBy(x: rect.width / 2, y: rect.height / 2)
+        context.scaleBy(x: 1.5, y: 1.5)
+        context.translateBy(x: -touchPoint.x, y: -touchPoint.y)
+        
+        image.draw(at: .zero)
+        
+        // Draw border ring
+        UIColor.white.setStroke()
+        let borderPath = UIBezierPath(ovalIn: rect.insetBy(dx: 1.5, dy: 1.5))
+        borderPath.lineWidth = 3
+        borderPath.stroke()
+        
+        // Draw crosshair in the center
+        UIColor.systemBlue.setStroke()
+        let crosshair = UIBezierPath()
+        let midX = rect.midX
+        let midY = rect.midY
+        crosshair.move(to: CGPoint(x: midX - 8, y: midY))
+        crosshair.addLine(to: CGPoint(x: midX + 8, y: midY))
+        crosshair.move(to: CGPoint(x: midX, y: midY - 8))
+        crosshair.addLine(to: CGPoint(x: midX, y: midY + 8))
+        crosshair.lineWidth = 1.5
+        crosshair.stroke()
+    }
+}

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/ar.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/ar.lproj/Localizable.strings
@@ -1,3 +1,6 @@
 "cunning_document_scanner_camera" = "الكاميرا";
 "cunning_document_scanner_gallery" = "مكتبة الصور";
 "cunning_document_scanner_cancel" = "إلغاء";
+"cunning_document_scanner_done" = "تم";
+"cunning_document_scanner_next" = "التالي";
+"cunning_document_scanner_crop_title" = "قص الصفحة %1$d من %2$d";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/ar.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/ar.lproj/Localizable.strings
@@ -1,6 +1,4 @@
 "cunning_document_scanner_camera" = "الكاميرا";
 "cunning_document_scanner_gallery" = "مكتبة الصور";
 "cunning_document_scanner_cancel" = "إلغاء";
-"cunning_document_scanner_done" = "تم";
-"cunning_document_scanner_next" = "التالي";
 "cunning_document_scanner_crop_title" = "قص الصفحة %1$d من %2$d";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/ar.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/ar.lproj/Localizable.strings
@@ -2,3 +2,6 @@
 "cunning_document_scanner_gallery" = "مكتبة الصور";
 "cunning_document_scanner_cancel" = "إلغاء";
 "cunning_document_scanner_crop_title" = "قص الصفحة %1$d من %2$d";
+"cunning_document_scanner_discard_title" = "تجاهل التغييرات؟";
+"cunning_document_scanner_discard_message" = "هل أنت متأكد أنك تريد تجاهل تقدمك؟";
+"cunning_document_scanner_discard" = "تجاهل";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/ca.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/ca.lproj/Localizable.strings
@@ -1,6 +1,4 @@
 "cunning_document_scanner_camera" = "Càmera";
 "cunning_document_scanner_gallery" = "Biblioteca de fotos";
 "cunning_document_scanner_cancel" = "Cancel·lar";
-"cunning_document_scanner_done" = "Fet";
-"cunning_document_scanner_next" = "Següent";
 "cunning_document_scanner_crop_title" = "Retallar pàgina %1$d de %2$d";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/ca.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/ca.lproj/Localizable.strings
@@ -2,3 +2,6 @@
 "cunning_document_scanner_gallery" = "Biblioteca de fotos";
 "cunning_document_scanner_cancel" = "Cancel·lar";
 "cunning_document_scanner_crop_title" = "Retallar pàgina %1$d de %2$d";
+"cunning_document_scanner_discard_title" = "Descartar els canvis?";
+"cunning_document_scanner_discard_message" = "Esteu segur que voleu descartar el vostre progrés?";
+"cunning_document_scanner_discard" = "Descartar";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/ca.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/ca.lproj/Localizable.strings
@@ -1,3 +1,6 @@
 "cunning_document_scanner_camera" = "Càmera";
 "cunning_document_scanner_gallery" = "Biblioteca de fotos";
 "cunning_document_scanner_cancel" = "Cancel·lar";
+"cunning_document_scanner_done" = "Fet";
+"cunning_document_scanner_next" = "Següent";
+"cunning_document_scanner_crop_title" = "Retallar pàgina %1$d de %2$d";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/cs.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/cs.lproj/Localizable.strings
@@ -2,3 +2,6 @@
 "cunning_document_scanner_gallery" = "Knihovna fotografií";
 "cunning_document_scanner_cancel" = "Zrušit";
 "cunning_document_scanner_crop_title" = "Oříznout stránku %1$d z %2$d";
+"cunning_document_scanner_discard_title" = "Zahodit změny?";
+"cunning_document_scanner_discard_message" = "Opravdu chcete zahodit svůj postup?";
+"cunning_document_scanner_discard" = "Zahodit";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/cs.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/cs.lproj/Localizable.strings
@@ -1,3 +1,6 @@
 "cunning_document_scanner_camera" = "Fotoaparát";
 "cunning_document_scanner_gallery" = "Knihovna fotografií";
 "cunning_document_scanner_cancel" = "Zrušit";
+"cunning_document_scanner_done" = "Hotovo";
+"cunning_document_scanner_next" = "Další";
+"cunning_document_scanner_crop_title" = "Oříznout stránku %1$d z %2$d";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/cs.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/cs.lproj/Localizable.strings
@@ -1,6 +1,4 @@
 "cunning_document_scanner_camera" = "Fotoaparát";
 "cunning_document_scanner_gallery" = "Knihovna fotografií";
 "cunning_document_scanner_cancel" = "Zrušit";
-"cunning_document_scanner_done" = "Hotovo";
-"cunning_document_scanner_next" = "Další";
 "cunning_document_scanner_crop_title" = "Oříznout stránku %1$d z %2$d";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/da.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/da.lproj/Localizable.strings
@@ -2,3 +2,6 @@
 "cunning_document_scanner_gallery" = "Fotobibliotek";
 "cunning_document_scanner_cancel" = "Annuller";
 "cunning_document_scanner_crop_title" = "Beskær side %1$d af %2$d";
+"cunning_document_scanner_discard_title" = "Kasser ændringer?";
+"cunning_document_scanner_discard_message" = "Er du sikker på, at du vil kassere dit fremskridt?";
+"cunning_document_scanner_discard" = "Kasser";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/da.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/da.lproj/Localizable.strings
@@ -1,6 +1,4 @@
 "cunning_document_scanner_camera" = "Kamera";
 "cunning_document_scanner_gallery" = "Fotobibliotek";
 "cunning_document_scanner_cancel" = "Annuller";
-"cunning_document_scanner_done" = "Udført";
-"cunning_document_scanner_next" = "Næste";
 "cunning_document_scanner_crop_title" = "Beskær side %1$d af %2$d";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/da.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/da.lproj/Localizable.strings
@@ -1,3 +1,6 @@
 "cunning_document_scanner_camera" = "Kamera";
 "cunning_document_scanner_gallery" = "Fotobibliotek";
 "cunning_document_scanner_cancel" = "Annuller";
+"cunning_document_scanner_done" = "Udført";
+"cunning_document_scanner_next" = "Næste";
+"cunning_document_scanner_crop_title" = "Beskær side %1$d af %2$d";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/de.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/de.lproj/Localizable.strings
@@ -1,6 +1,4 @@
 "cunning_document_scanner_camera" = "Kamera";
 "cunning_document_scanner_gallery" = "Fotomediathek";
 "cunning_document_scanner_cancel" = "Abbrechen";
-"cunning_document_scanner_done" = "Fertig";
-"cunning_document_scanner_next" = "Weiter";
 "cunning_document_scanner_crop_title" = "Seite %1$d von %2$d zuschneiden";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/de.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/de.lproj/Localizable.strings
@@ -1,3 +1,6 @@
 "cunning_document_scanner_camera" = "Kamera";
 "cunning_document_scanner_gallery" = "Fotomediathek";
 "cunning_document_scanner_cancel" = "Abbrechen";
+"cunning_document_scanner_done" = "Fertig";
+"cunning_document_scanner_next" = "Weiter";
+"cunning_document_scanner_crop_title" = "Seite %1$d von %2$d zuschneiden";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/de.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/de.lproj/Localizable.strings
@@ -2,3 +2,6 @@
 "cunning_document_scanner_gallery" = "Fotomediathek";
 "cunning_document_scanner_cancel" = "Abbrechen";
 "cunning_document_scanner_crop_title" = "Seite %1$d von %2$d zuschneiden";
+"cunning_document_scanner_discard_title" = "Änderungen verwerfen?";
+"cunning_document_scanner_discard_message" = "Sind Sie sicher, dass Sie Ihren Fortschritt verwerfen möchten?";
+"cunning_document_scanner_discard" = "Verwerfen";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/el.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/el.lproj/Localizable.strings
@@ -2,3 +2,6 @@
 "cunning_document_scanner_gallery" = "Βιβλιοθήκη φωτογραφιών";
 "cunning_document_scanner_cancel" = "Ακύρωση";
 "cunning_document_scanner_crop_title" = "Περικοπή σελίδας %1$d από %2$d";
+"cunning_document_scanner_discard_title" = "Απόρριψη αλλαγών;";
+"cunning_document_scanner_discard_message" = "Είστε βέβαιοι ότι θέλετε να απορρίψετε την πρόοδό σας;";
+"cunning_document_scanner_discard" = "Απόρριψη";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/el.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/el.lproj/Localizable.strings
@@ -1,6 +1,4 @@
 "cunning_document_scanner_camera" = "Κάμερα";
 "cunning_document_scanner_gallery" = "Βιβλιοθήκη φωτογραφιών";
 "cunning_document_scanner_cancel" = "Ακύρωση";
-"cunning_document_scanner_done" = "Τέλος";
-"cunning_document_scanner_next" = "Επόμενο";
 "cunning_document_scanner_crop_title" = "Περικοπή σελίδας %1$d από %2$d";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/el.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/el.lproj/Localizable.strings
@@ -1,3 +1,6 @@
 "cunning_document_scanner_camera" = "Κάμερα";
 "cunning_document_scanner_gallery" = "Βιβλιοθήκη φωτογραφιών";
 "cunning_document_scanner_cancel" = "Ακύρωση";
+"cunning_document_scanner_done" = "Τέλος";
+"cunning_document_scanner_next" = "Επόμενο";
+"cunning_document_scanner_crop_title" = "Περικοπή σελίδας %1$d από %2$d";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/en.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/en.lproj/Localizable.strings
@@ -1,6 +1,4 @@
 "cunning_document_scanner_camera" = "Camera";
 "cunning_document_scanner_gallery" = "Photo Library";
 "cunning_document_scanner_cancel" = "Cancel";
-"cunning_document_scanner_done" = "Done";
-"cunning_document_scanner_next" = "Next";
 "cunning_document_scanner_crop_title" = "Crop Page %1$d of %2$d";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/en.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/en.lproj/Localizable.strings
@@ -2,3 +2,6 @@
 "cunning_document_scanner_gallery" = "Photo Library";
 "cunning_document_scanner_cancel" = "Cancel";
 "cunning_document_scanner_crop_title" = "Crop Page %1$d of %2$d";
+"cunning_document_scanner_discard_title" = "Discard changes?";
+"cunning_document_scanner_discard_message" = "Are you sure you want to discard your progress?";
+"cunning_document_scanner_discard" = "Discard";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/en.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/en.lproj/Localizable.strings
@@ -1,3 +1,6 @@
 "cunning_document_scanner_camera" = "Camera";
 "cunning_document_scanner_gallery" = "Photo Library";
 "cunning_document_scanner_cancel" = "Cancel";
+"cunning_document_scanner_done" = "Done";
+"cunning_document_scanner_next" = "Next";
+"cunning_document_scanner_crop_title" = "Crop Page %1$d of %2$d";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/es.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/es.lproj/Localizable.strings
@@ -1,6 +1,4 @@
 "cunning_document_scanner_camera" = "Cámara";
 "cunning_document_scanner_gallery" = "Fototeca";
 "cunning_document_scanner_cancel" = "Cancelar";
-"cunning_document_scanner_done" = "Hecho";
-"cunning_document_scanner_next" = "Siguiente";
 "cunning_document_scanner_crop_title" = "Recortar página %1$d de %2$d";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/es.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/es.lproj/Localizable.strings
@@ -2,3 +2,6 @@
 "cunning_document_scanner_gallery" = "Fototeca";
 "cunning_document_scanner_cancel" = "Cancelar";
 "cunning_document_scanner_crop_title" = "Recortar página %1$d de %2$d";
+"cunning_document_scanner_discard_title" = "¿Descartar cambios?";
+"cunning_document_scanner_discard_message" = "¿Está seguro de que desea descartar su progreso?";
+"cunning_document_scanner_discard" = "Descartar";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/es.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/es.lproj/Localizable.strings
@@ -1,3 +1,6 @@
 "cunning_document_scanner_camera" = "Cámara";
 "cunning_document_scanner_gallery" = "Fototeca";
 "cunning_document_scanner_cancel" = "Cancelar";
+"cunning_document_scanner_done" = "Hecho";
+"cunning_document_scanner_next" = "Siguiente";
+"cunning_document_scanner_crop_title" = "Recortar página %1$d de %2$d";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/fi.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/fi.lproj/Localizable.strings
@@ -1,3 +1,6 @@
 "cunning_document_scanner_camera" = "Kamera";
 "cunning_document_scanner_gallery" = "Kuvakirjasto";
 "cunning_document_scanner_cancel" = "Peruuta";
+"cunning_document_scanner_done" = "Valmis";
+"cunning_document_scanner_next" = "Seuraava";
+"cunning_document_scanner_crop_title" = "Rajaa sivu %1$d/%2$d";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/fi.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/fi.lproj/Localizable.strings
@@ -1,6 +1,4 @@
 "cunning_document_scanner_camera" = "Kamera";
 "cunning_document_scanner_gallery" = "Kuvakirjasto";
 "cunning_document_scanner_cancel" = "Peruuta";
-"cunning_document_scanner_done" = "Valmis";
-"cunning_document_scanner_next" = "Seuraava";
 "cunning_document_scanner_crop_title" = "Rajaa sivu %1$d/%2$d";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/fi.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/fi.lproj/Localizable.strings
@@ -2,3 +2,6 @@
 "cunning_document_scanner_gallery" = "Kuvakirjasto";
 "cunning_document_scanner_cancel" = "Peruuta";
 "cunning_document_scanner_crop_title" = "Rajaa sivu %1$d/%2$d";
+"cunning_document_scanner_discard_title" = "Hylätäänkö muutokset?";
+"cunning_document_scanner_discard_message" = "Haluatko varmasti hylätä edistymisesi?";
+"cunning_document_scanner_discard" = "Hylkää";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/fr.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/fr.lproj/Localizable.strings
@@ -1,6 +1,4 @@
 "cunning_document_scanner_camera" = "Appareil photo";
 "cunning_document_scanner_gallery" = "Photothèque";
 "cunning_document_scanner_cancel" = "Annuler";
-"cunning_document_scanner_done" = "Terminé";
-"cunning_document_scanner_next" = "Suivant";
 "cunning_document_scanner_crop_title" = "Rogner la page %1$d sur %2$d";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/fr.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/fr.lproj/Localizable.strings
@@ -2,3 +2,6 @@
 "cunning_document_scanner_gallery" = "Photothèque";
 "cunning_document_scanner_cancel" = "Annuler";
 "cunning_document_scanner_crop_title" = "Rogner la page %1$d sur %2$d";
+"cunning_document_scanner_discard_title" = "Abandonner les modifications ?";
+"cunning_document_scanner_discard_message" = "Voulez-vous vraiment abandonner votre progression ?";
+"cunning_document_scanner_discard" = "Abandonner";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/fr.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/fr.lproj/Localizable.strings
@@ -1,3 +1,6 @@
 "cunning_document_scanner_camera" = "Appareil photo";
 "cunning_document_scanner_gallery" = "Photothèque";
 "cunning_document_scanner_cancel" = "Annuler";
+"cunning_document_scanner_done" = "Terminé";
+"cunning_document_scanner_next" = "Suivant";
+"cunning_document_scanner_crop_title" = "Rogner la page %1$d sur %2$d";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/he.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/he.lproj/Localizable.strings
@@ -1,6 +1,4 @@
 "cunning_document_scanner_camera" = "מצלמה";
 "cunning_document_scanner_gallery" = "ספריית תמונות";
 "cunning_document_scanner_cancel" = "ביטول";
-"cunning_document_scanner_done" = "בוצע";
-"cunning_document_scanner_next" = "הבא";
 "cunning_document_scanner_crop_title" = "חתוך עמוד %1$d מתוך %2$d";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/he.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/he.lproj/Localizable.strings
@@ -1,3 +1,6 @@
 "cunning_document_scanner_camera" = "מצלמה";
 "cunning_document_scanner_gallery" = "ספריית תמונות";
 "cunning_document_scanner_cancel" = "ביטول";
+"cunning_document_scanner_done" = "בוצע";
+"cunning_document_scanner_next" = "הבא";
+"cunning_document_scanner_crop_title" = "חתוך עמוד %1$d מתוך %2$d";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/he.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/he.lproj/Localizable.strings
@@ -2,3 +2,6 @@
 "cunning_document_scanner_gallery" = "ספריית תמונות";
 "cunning_document_scanner_cancel" = "ביטول";
 "cunning_document_scanner_crop_title" = "חתוך עמוד %1$d מתוך %2$d";
+"cunning_document_scanner_discard_title" = "למחוק את השינויים?";
+"cunning_document_scanner_discard_message" = "האם אתה בטוח שברצונך למחוק את ההתקדמות שלך?";
+"cunning_document_scanner_discard" = "למחוק";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/hi.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/hi.lproj/Localizable.strings
@@ -2,3 +2,6 @@
 "cunning_document_scanner_gallery" = "फ़ोटो लाइब्रेरी";
 "cunning_document_scanner_cancel" = "रद्द करें";
 "cunning_document_scanner_crop_title" = "%2$d में से %1$d पृष्ठ क्रॉप करें";
+"cunning_document_scanner_discard_title" = "बदलावों को खारिज करें?";
+"cunning_document_scanner_discard_message" = "क्या आप वाकई अपनी प्रगति को खारिज करना चाहते हैं?";
+"cunning_document_scanner_discard" = "खारिज करें";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/hi.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/hi.lproj/Localizable.strings
@@ -1,3 +1,6 @@
 "cunning_document_scanner_camera" = "कैमरा";
 "cunning_document_scanner_gallery" = "फ़ोटो लाइब्रेरी";
 "cunning_document_scanner_cancel" = "रद्द करें";
+"cunning_document_scanner_done" = "हो गया";
+"cunning_document_scanner_next" = "अगला";
+"cunning_document_scanner_crop_title" = "%2$d में से %1$d पृष्ठ क्रॉप करें";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/hi.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/hi.lproj/Localizable.strings
@@ -1,6 +1,4 @@
 "cunning_document_scanner_camera" = "कैमरा";
 "cunning_document_scanner_gallery" = "फ़ोटो लाइब्रेरी";
 "cunning_document_scanner_cancel" = "रद्द करें";
-"cunning_document_scanner_done" = "हो गया";
-"cunning_document_scanner_next" = "अगला";
 "cunning_document_scanner_crop_title" = "%2$d में से %1$d पृष्ठ क्रॉप करें";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/id.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/id.lproj/Localizable.strings
@@ -1,6 +1,4 @@
 "cunning_document_scanner_camera" = "Kamera";
 "cunning_document_scanner_gallery" = "Perpustakaan Foto";
 "cunning_document_scanner_cancel" = "Batal";
-"cunning_document_scanner_done" = "Selesai";
-"cunning_document_scanner_next" = "Berikutnya";
 "cunning_document_scanner_crop_title" = "Pangkas Halaman %1$d dari %2$d";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/id.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/id.lproj/Localizable.strings
@@ -2,3 +2,6 @@
 "cunning_document_scanner_gallery" = "Perpustakaan Foto";
 "cunning_document_scanner_cancel" = "Batal";
 "cunning_document_scanner_crop_title" = "Pangkas Halaman %1$d dari %2$d";
+"cunning_document_scanner_discard_title" = "Buang perubahan?";
+"cunning_document_scanner_discard_message" = "Apakah Anda yakin ingin membuang kemajuan Anda?";
+"cunning_document_scanner_discard" = "Buang";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/id.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/id.lproj/Localizable.strings
@@ -1,3 +1,6 @@
 "cunning_document_scanner_camera" = "Kamera";
 "cunning_document_scanner_gallery" = "Perpustakaan Foto";
 "cunning_document_scanner_cancel" = "Batal";
+"cunning_document_scanner_done" = "Selesai";
+"cunning_document_scanner_next" = "Berikutnya";
+"cunning_document_scanner_crop_title" = "Pangkas Halaman %1$d dari %2$d";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/it.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/it.lproj/Localizable.strings
@@ -1,6 +1,4 @@
 "cunning_document_scanner_camera" = "Fotocamera";
 "cunning_document_scanner_gallery" = "Libreria foto";
 "cunning_document_scanner_cancel" = "Annulla";
-"cunning_document_scanner_done" = "Fine";
-"cunning_document_scanner_next" = "Avanti";
 "cunning_document_scanner_crop_title" = "Ritaglia pagina %1$d di %2$d";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/it.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/it.lproj/Localizable.strings
@@ -1,3 +1,6 @@
 "cunning_document_scanner_camera" = "Fotocamera";
 "cunning_document_scanner_gallery" = "Libreria foto";
 "cunning_document_scanner_cancel" = "Annulla";
+"cunning_document_scanner_done" = "Fine";
+"cunning_document_scanner_next" = "Avanti";
+"cunning_document_scanner_crop_title" = "Ritaglia pagina %1$d di %2$d";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/it.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/it.lproj/Localizable.strings
@@ -2,3 +2,6 @@
 "cunning_document_scanner_gallery" = "Libreria foto";
 "cunning_document_scanner_cancel" = "Annulla";
 "cunning_document_scanner_crop_title" = "Ritaglia pagina %1$d di %2$d";
+"cunning_document_scanner_discard_title" = "Annullare le modifiche?";
+"cunning_document_scanner_discard_message" = "Sei sicuro di voler annullare i tuoi progressi?";
+"cunning_document_scanner_discard" = "Annulla";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/ja.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/ja.lproj/Localizable.strings
@@ -1,6 +1,4 @@
 "cunning_document_scanner_camera" = "カメラ";
 "cunning_document_scanner_gallery" = "写真ライブラリ";
 "cunning_document_scanner_cancel" = "キャンセル";
-"cunning_document_scanner_done" = "完了";
-"cunning_document_scanner_next" = "次へ";
 "cunning_document_scanner_crop_title" = "ページ %1$d / %2$d を切り抜き";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/ja.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/ja.lproj/Localizable.strings
@@ -1,3 +1,6 @@
 "cunning_document_scanner_camera" = "カメラ";
 "cunning_document_scanner_gallery" = "写真ライブラリ";
 "cunning_document_scanner_cancel" = "キャンセル";
+"cunning_document_scanner_done" = "完了";
+"cunning_document_scanner_next" = "次へ";
+"cunning_document_scanner_crop_title" = "ページ %1$d / %2$d を切り抜き";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/ja.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/ja.lproj/Localizable.strings
@@ -2,3 +2,6 @@
 "cunning_document_scanner_gallery" = "写真ライブラリ";
 "cunning_document_scanner_cancel" = "キャンセル";
 "cunning_document_scanner_crop_title" = "ページ %1$d / %2$d を切り抜き";
+"cunning_document_scanner_discard_title" = "変更を破棄しますか？";
+"cunning_document_scanner_discard_message" = "これまでの進行状況を破棄してもよろしいですか？";
+"cunning_document_scanner_discard" = "破棄";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/ko.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/ko.lproj/Localizable.strings
@@ -2,3 +2,6 @@
 "cunning_document_scanner_gallery" = "사진 보관함";
 "cunning_document_scanner_cancel" = "취소";
 "cunning_document_scanner_crop_title" = "%2$d페이지 중 %1$d페이지 자르기";
+"cunning_document_scanner_discard_title" = "변경사항을 취소하시겠습니까?";
+"cunning_document_scanner_discard_message" = "지금까지의 진행 상황을 취소하시겠습니까?";
+"cunning_document_scanner_discard" = "취소";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/ko.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/ko.lproj/Localizable.strings
@@ -1,3 +1,6 @@
 "cunning_document_scanner_camera" = "카메라";
 "cunning_document_scanner_gallery" = "사진 보관함";
 "cunning_document_scanner_cancel" = "취소";
+"cunning_document_scanner_done" = "완료";
+"cunning_document_scanner_next" = "다음";
+"cunning_document_scanner_crop_title" = "%2$d페이지 중 %1$d페이지 자르기";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/ko.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/ko.lproj/Localizable.strings
@@ -1,6 +1,4 @@
 "cunning_document_scanner_camera" = "카메라";
 "cunning_document_scanner_gallery" = "사진 보관함";
 "cunning_document_scanner_cancel" = "취소";
-"cunning_document_scanner_done" = "완료";
-"cunning_document_scanner_next" = "다음";
 "cunning_document_scanner_crop_title" = "%2$d페이지 중 %1$d페이지 자르기";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/nb.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/nb.lproj/Localizable.strings
@@ -1,3 +1,6 @@
 "cunning_document_scanner_camera" = "Kamera";
 "cunning_document_scanner_gallery" = "Bildebibliotek";
 "cunning_document_scanner_cancel" = "Avbryt";
+"cunning_document_scanner_done" = "Ferdig";
+"cunning_document_scanner_next" = "Neste";
+"cunning_document_scanner_crop_title" = "Beskjær side %1$d av %2$d";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/nb.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/nb.lproj/Localizable.strings
@@ -1,6 +1,4 @@
 "cunning_document_scanner_camera" = "Kamera";
 "cunning_document_scanner_gallery" = "Bildebibliotek";
 "cunning_document_scanner_cancel" = "Avbryt";
-"cunning_document_scanner_done" = "Ferdig";
-"cunning_document_scanner_next" = "Neste";
 "cunning_document_scanner_crop_title" = "Beskjær side %1$d av %2$d";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/nb.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/nb.lproj/Localizable.strings
@@ -2,3 +2,6 @@
 "cunning_document_scanner_gallery" = "Bildebibliotek";
 "cunning_document_scanner_cancel" = "Avbryt";
 "cunning_document_scanner_crop_title" = "Beskjær side %1$d av %2$d";
+"cunning_document_scanner_discard_title" = "Forkast endringer?";
+"cunning_document_scanner_discard_message" = "Er du sikker på at du vil forkaste fremgangen din?";
+"cunning_document_scanner_discard" = "Forkast";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/nl.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/nl.lproj/Localizable.strings
@@ -1,3 +1,6 @@
 "cunning_document_scanner_camera" = "Camera";
 "cunning_document_scanner_gallery" = "Fotobibliotheek";
 "cunning_document_scanner_cancel" = "Annuleren";
+"cunning_document_scanner_done" = "Gereed";
+"cunning_document_scanner_next" = "Volgende";
+"cunning_document_scanner_crop_title" = "Pagina %1$d van %2$d bijsnijden";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/nl.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/nl.lproj/Localizable.strings
@@ -2,3 +2,6 @@
 "cunning_document_scanner_gallery" = "Fotobibliotheek";
 "cunning_document_scanner_cancel" = "Annuleren";
 "cunning_document_scanner_crop_title" = "Pagina %1$d van %2$d bijsnijden";
+"cunning_document_scanner_discard_title" = "Wijzigingen weggooien?";
+"cunning_document_scanner_discard_message" = "Weet u zeker dat u uw voortgang wilt weggooien?";
+"cunning_document_scanner_discard" = "Weggooien";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/nl.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/nl.lproj/Localizable.strings
@@ -1,6 +1,4 @@
 "cunning_document_scanner_camera" = "Camera";
 "cunning_document_scanner_gallery" = "Fotobibliotheek";
 "cunning_document_scanner_cancel" = "Annuleren";
-"cunning_document_scanner_done" = "Gereed";
-"cunning_document_scanner_next" = "Volgende";
 "cunning_document_scanner_crop_title" = "Pagina %1$d van %2$d bijsnijden";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/pl.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/pl.lproj/Localizable.strings
@@ -1,3 +1,6 @@
 "cunning_document_scanner_camera" = "Aparat";
 "cunning_document_scanner_gallery" = "Biblioteka zdjęć";
 "cunning_document_scanner_cancel" = "Anuluj";
+"cunning_document_scanner_done" = "Gotowe";
+"cunning_document_scanner_next" = "Dalej";
+"cunning_document_scanner_crop_title" = "Przytnij stronę %1$d z %2$d";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/pl.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/pl.lproj/Localizable.strings
@@ -2,3 +2,6 @@
 "cunning_document_scanner_gallery" = "Biblioteka zdjęć";
 "cunning_document_scanner_cancel" = "Anuluj";
 "cunning_document_scanner_crop_title" = "Przytnij stronę %1$d z %2$d";
+"cunning_document_scanner_discard_title" = "Odrzucić zmiany?";
+"cunning_document_scanner_discard_message" = "Czy na pewno chcesz odrzucić swoje postępy?";
+"cunning_document_scanner_discard" = "Odrzuć";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/pl.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/pl.lproj/Localizable.strings
@@ -1,6 +1,4 @@
 "cunning_document_scanner_camera" = "Aparat";
 "cunning_document_scanner_gallery" = "Biblioteka zdjęć";
 "cunning_document_scanner_cancel" = "Anuluj";
-"cunning_document_scanner_done" = "Gotowe";
-"cunning_document_scanner_next" = "Dalej";
 "cunning_document_scanner_crop_title" = "Przytnij stronę %1$d z %2$d";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/pt.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/pt.lproj/Localizable.strings
@@ -2,3 +2,6 @@
 "cunning_document_scanner_gallery" = "Fototeca";
 "cunning_document_scanner_cancel" = "Cancelar";
 "cunning_document_scanner_crop_title" = "Recortar página %1$d de %2$d";
+"cunning_document_scanner_discard_title" = "Descartar alterações?";
+"cunning_document_scanner_discard_message" = "Tem a certeza de que deseja descartar o seu progresso?";
+"cunning_document_scanner_discard" = "Descartar";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/pt.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/pt.lproj/Localizable.strings
@@ -1,3 +1,6 @@
 "cunning_document_scanner_camera" = "Câmera";
 "cunning_document_scanner_gallery" = "Fototeca";
 "cunning_document_scanner_cancel" = "Cancelar";
+"cunning_document_scanner_done" = "Concluído";
+"cunning_document_scanner_next" = "Seguinte";
+"cunning_document_scanner_crop_title" = "Recortar página %1$d de %2$d";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/pt.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/pt.lproj/Localizable.strings
@@ -1,6 +1,4 @@
 "cunning_document_scanner_camera" = "Câmera";
 "cunning_document_scanner_gallery" = "Fototeca";
 "cunning_document_scanner_cancel" = "Cancelar";
-"cunning_document_scanner_done" = "Concluído";
-"cunning_document_scanner_next" = "Seguinte";
 "cunning_document_scanner_crop_title" = "Recortar página %1$d de %2$d";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/ro.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/ro.lproj/Localizable.strings
@@ -1,6 +1,4 @@
 "cunning_document_scanner_camera" = "Cameră";
 "cunning_document_scanner_gallery" = "Librărie foto";
 "cunning_document_scanner_cancel" = "Anulează";
-"cunning_document_scanner_done" = "Gata";
-"cunning_document_scanner_next" = "Înainte";
 "cunning_document_scanner_crop_title" = "Decupați pagina %1$d din %2$d";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/ro.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/ro.lproj/Localizable.strings
@@ -2,3 +2,6 @@
 "cunning_document_scanner_gallery" = "Librărie foto";
 "cunning_document_scanner_cancel" = "Anulează";
 "cunning_document_scanner_crop_title" = "Decupați pagina %1$d din %2$d";
+"cunning_document_scanner_discard_title" = "Renunțați la modificări?";
+"cunning_document_scanner_discard_message" = "Sigur doriți să renunțați la progresul realizat?";
+"cunning_document_scanner_discard" = "Renunțare";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/ro.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/ro.lproj/Localizable.strings
@@ -1,3 +1,6 @@
 "cunning_document_scanner_camera" = "Cameră";
 "cunning_document_scanner_gallery" = "Librărie foto";
 "cunning_document_scanner_cancel" = "Anulează";
+"cunning_document_scanner_done" = "Gata";
+"cunning_document_scanner_next" = "Înainte";
+"cunning_document_scanner_crop_title" = "Decupați pagina %1$d din %2$d";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/ru.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/ru.lproj/Localizable.strings
@@ -1,3 +1,6 @@
 "cunning_document_scanner_camera" = "Камера";
 "cunning_document_scanner_gallery" = "Медиатека";
 "cunning_document_scanner_cancel" = "Отмена";
+"cunning_document_scanner_done" = "Готово";
+"cunning_document_scanner_next" = "Далее";
+"cunning_document_scanner_crop_title" = "Обрезать страницу %1$d из %2$d";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/ru.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/ru.lproj/Localizable.strings
@@ -2,3 +2,6 @@
 "cunning_document_scanner_gallery" = "Медиатека";
 "cunning_document_scanner_cancel" = "Отмена";
 "cunning_document_scanner_crop_title" = "Обрезать страницу %1$d из %2$d";
+"cunning_document_scanner_discard_title" = "Сбросить изменения?";
+"cunning_document_scanner_discard_message" = "Вы уверены, что хотите сбросить свой прогресс?";
+"cunning_document_scanner_discard" = "Сбросить";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/ru.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/ru.lproj/Localizable.strings
@@ -1,6 +1,4 @@
 "cunning_document_scanner_camera" = "Камера";
 "cunning_document_scanner_gallery" = "Медиатека";
 "cunning_document_scanner_cancel" = "Отмена";
-"cunning_document_scanner_done" = "Готово";
-"cunning_document_scanner_next" = "Далее";
 "cunning_document_scanner_crop_title" = "Обрезать страницу %1$d из %2$d";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/sv.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/sv.lproj/Localizable.strings
@@ -1,3 +1,6 @@
 "cunning_document_scanner_camera" = "Kamera";
 "cunning_document_scanner_gallery" = "Bildbibliotek";
 "cunning_document_scanner_cancel" = "Avbryt";
+"cunning_document_scanner_done" = "Klar";
+"cunning_document_scanner_next" = "Nästa";
+"cunning_document_scanner_crop_title" = "Beskär sida %1$d av %2$d";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/sv.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/sv.lproj/Localizable.strings
@@ -2,3 +2,6 @@
 "cunning_document_scanner_gallery" = "Bildbibliotek";
 "cunning_document_scanner_cancel" = "Avbryt";
 "cunning_document_scanner_crop_title" = "Beskär sida %1$d av %2$d";
+"cunning_document_scanner_discard_title" = "Forkasta ändringar?";
+"cunning_document_scanner_discard_message" = "Är du säker på att du vil forkasta dina framsteg?";
+"cunning_document_scanner_discard" = "Forkasta";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/sv.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/sv.lproj/Localizable.strings
@@ -1,6 +1,4 @@
 "cunning_document_scanner_camera" = "Kamera";
 "cunning_document_scanner_gallery" = "Bildbibliotek";
 "cunning_document_scanner_cancel" = "Avbryt";
-"cunning_document_scanner_done" = "Klar";
-"cunning_document_scanner_next" = "Nästa";
 "cunning_document_scanner_crop_title" = "Beskär sida %1$d av %2$d";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/th.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/th.lproj/Localizable.strings
@@ -2,3 +2,6 @@
 "cunning_document_scanner_gallery" = "คลังรูปภาพ";
 "cunning_document_scanner_cancel" = "ยกเลิก";
 "cunning_document_scanner_crop_title" = "ครอบตัดหน้า %1$d จาก %2$d";
+"cunning_document_scanner_discard_title" = "ละทิ้งการเปลี่ยนแปลง?";
+"cunning_document_scanner_discard_message" = "คุณแน่ใจหรือไม่ว่าต้องการละทิ้งความคืบหน้าของคุณ?";
+"cunning_document_scanner_discard" = "ละทิ้ง";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/th.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/th.lproj/Localizable.strings
@@ -1,3 +1,6 @@
 "cunning_document_scanner_camera" = "กล้อง";
 "cunning_document_scanner_gallery" = "คลังรูปภาพ";
 "cunning_document_scanner_cancel" = "ยกเลิก";
+"cunning_document_scanner_done" = "เสร็จสิ้น";
+"cunning_document_scanner_next" = "ถัดไป";
+"cunning_document_scanner_crop_title" = "ครอบตัดหน้า %1$d จาก %2$d";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/th.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/th.lproj/Localizable.strings
@@ -1,6 +1,4 @@
 "cunning_document_scanner_camera" = "กล้อง";
 "cunning_document_scanner_gallery" = "คลังรูปภาพ";
 "cunning_document_scanner_cancel" = "ยกเลิก";
-"cunning_document_scanner_done" = "เสร็จสิ้น";
-"cunning_document_scanner_next" = "ถัดไป";
 "cunning_document_scanner_crop_title" = "ครอบตัดหน้า %1$d จาก %2$d";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/tr.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/tr.lproj/Localizable.strings
@@ -1,3 +1,6 @@
 "cunning_document_scanner_camera" = "Kamera";
 "cunning_document_scanner_gallery" = "Fotoğraf Kitaplığı";
 "cunning_document_scanner_cancel" = "İptal";
+"cunning_document_scanner_done" = "Bitti";
+"cunning_document_scanner_next" = "Sonraki";
+"cunning_document_scanner_crop_title" = "Sayfa %1$d / %2$d kırp";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/tr.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/tr.lproj/Localizable.strings
@@ -2,3 +2,6 @@
 "cunning_document_scanner_gallery" = "Fotoğraf Kitaplığı";
 "cunning_document_scanner_cancel" = "İptal";
 "cunning_document_scanner_crop_title" = "Sayfa %1$d / %2$d kırp";
+"cunning_document_scanner_discard_title" = "Değişiklikleri iptal et?";
+"cunning_document_scanner_discard_message" = "İlerlemenizi iptal etmek istediğinizden emin misiniz?";
+"cunning_document_scanner_discard" = "İptal et";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/tr.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/tr.lproj/Localizable.strings
@@ -1,6 +1,4 @@
 "cunning_document_scanner_camera" = "Kamera";
 "cunning_document_scanner_gallery" = "Fotoğraf Kitaplığı";
 "cunning_document_scanner_cancel" = "İptal";
-"cunning_document_scanner_done" = "Bitti";
-"cunning_document_scanner_next" = "Sonraki";
 "cunning_document_scanner_crop_title" = "Sayfa %1$d / %2$d kırp";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/uk.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/uk.lproj/Localizable.strings
@@ -2,3 +2,6 @@
 "cunning_document_scanner_gallery" = "Бібліотека фото";
 "cunning_document_scanner_cancel" = "Скасувати";
 "cunning_document_scanner_crop_title" = "Обрізати сторінку %1$d з %2$d";
+"cunning_document_scanner_discard_title" = "Скасувати зміни?";
+"cunning_document_scanner_discard_message" = "Ви впевнені, що хочете скасувати свій прогрес?";
+"cunning_document_scanner_discard" = "Скасувати";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/uk.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/uk.lproj/Localizable.strings
@@ -1,3 +1,6 @@
 "cunning_document_scanner_camera" = "Камера";
 "cunning_document_scanner_gallery" = "Бібліотека фото";
 "cunning_document_scanner_cancel" = "Скасувати";
+"cunning_document_scanner_done" = "Готово";
+"cunning_document_scanner_next" = "Далі";
+"cunning_document_scanner_crop_title" = "Обрізати сторінку %1$d з %2$d";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/uk.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/uk.lproj/Localizable.strings
@@ -1,6 +1,4 @@
 "cunning_document_scanner_camera" = "Камера";
 "cunning_document_scanner_gallery" = "Бібліотека фото";
 "cunning_document_scanner_cancel" = "Скасувати";
-"cunning_document_scanner_done" = "Готово";
-"cunning_document_scanner_next" = "Далі";
 "cunning_document_scanner_crop_title" = "Обрізати сторінку %1$d з %2$d";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/vi.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/vi.lproj/Localizable.strings
@@ -2,3 +2,6 @@
 "cunning_document_scanner_gallery" = "Thư viện ảnh";
 "cunning_document_scanner_cancel" = "Hủy";
 "cunning_document_scanner_crop_title" = "Cắt trang %1$d / %2$d";
+"cunning_document_scanner_discard_title" = "Hủy bỏ các thay đổi?";
+"cunning_document_scanner_discard_message" = "Bạn có chắc chắn muốn hủy bỏ tiến trình của mình không?";
+"cunning_document_scanner_discard" = "Hủy bỏ";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/vi.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/vi.lproj/Localizable.strings
@@ -1,3 +1,6 @@
 "cunning_document_scanner_camera" = "Máy ảnh";
 "cunning_document_scanner_gallery" = "Thư viện ảnh";
 "cunning_document_scanner_cancel" = "Hủy";
+"cunning_document_scanner_done" = "Xong";
+"cunning_document_scanner_next" = "Tiếp theo";
+"cunning_document_scanner_crop_title" = "Cắt trang %1$d / %2$d";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/vi.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/vi.lproj/Localizable.strings
@@ -1,6 +1,4 @@
 "cunning_document_scanner_camera" = "Máy ảnh";
 "cunning_document_scanner_gallery" = "Thư viện ảnh";
 "cunning_document_scanner_cancel" = "Hủy";
-"cunning_document_scanner_done" = "Xong";
-"cunning_document_scanner_next" = "Tiếp theo";
 "cunning_document_scanner_crop_title" = "Cắt trang %1$d / %2$d";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/zh-Hans.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/zh-Hans.lproj/Localizable.strings
@@ -2,3 +2,6 @@
 "cunning_document_scanner_gallery" = "照片图库";
 "cunning_document_scanner_cancel" = "取消";
 "cunning_document_scanner_crop_title" = "裁剪第 %1$d 页（共 %2$d 页）";
+"cunning_document_scanner_discard_title" = "放弃更改吗？";
+"cunning_document_scanner_discard_message" = "您确定要放弃当前的进度吗？";
+"cunning_document_scanner_discard" = "放弃";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/zh-Hans.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/zh-Hans.lproj/Localizable.strings
@@ -1,6 +1,4 @@
 "cunning_document_scanner_camera" = "相机";
 "cunning_document_scanner_gallery" = "照片图库";
 "cunning_document_scanner_cancel" = "取消";
-"cunning_document_scanner_done" = "完成";
-"cunning_document_scanner_next" = "下一步";
 "cunning_document_scanner_crop_title" = "裁剪第 %1$d 页（共 %2$d 页）";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/zh-Hans.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/zh-Hans.lproj/Localizable.strings
@@ -1,3 +1,6 @@
 "cunning_document_scanner_camera" = "相机";
 "cunning_document_scanner_gallery" = "照片图库";
 "cunning_document_scanner_cancel" = "取消";
+"cunning_document_scanner_done" = "完成";
+"cunning_document_scanner_next" = "下一步";
+"cunning_document_scanner_crop_title" = "裁剪第 %1$d 页（共 %2$d 页）";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/zh-Hant.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/zh-Hant.lproj/Localizable.strings
@@ -2,3 +2,6 @@
 "cunning_document_scanner_gallery" = "照片圖庫";
 "cunning_document_scanner_cancel" = "取消";
 "cunning_document_scanner_crop_title" = "裁剪第 %1$d 頁（共 %2$d 頁）";
+"cunning_document_scanner_discard_title" = "放棄變更嗎？";
+"cunning_document_scanner_discard_message" = "您確定要放棄目前的進度嗎？";
+"cunning_document_scanner_discard" = "放棄";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/zh-Hant.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/zh-Hant.lproj/Localizable.strings
@@ -1,6 +1,4 @@
 "cunning_document_scanner_camera" = "相機";
 "cunning_document_scanner_gallery" = "照片圖庫";
 "cunning_document_scanner_cancel" = "取消";
-"cunning_document_scanner_done" = "完成";
-"cunning_document_scanner_next" = "下一步";
 "cunning_document_scanner_crop_title" = "裁剪第 %1$d 頁（共 %2$d 頁）";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/zh-Hant.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/zh-Hant.lproj/Localizable.strings
@@ -1,3 +1,6 @@
 "cunning_document_scanner_camera" = "相機";
 "cunning_document_scanner_gallery" = "照片圖庫";
 "cunning_document_scanner_cancel" = "取消";
+"cunning_document_scanner_done" = "完成";
+"cunning_document_scanner_next" = "下一步";
+"cunning_document_scanner_crop_title" = "裁剪第 %1$d 頁（共 %2$d 頁）";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/UIImage+Orientation.swift
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/UIImage+Orientation.swift
@@ -1,0 +1,85 @@
+import UIKit
+import ImageIO
+
+// MARK: - UIImage Extension (Fix Orientation, Rotation, Downscaling)
+
+extension UIImage {
+    
+    /// Returns a new UIImage with upright (.up) orientation.
+    /// It forces the redraw of pixels into a graphics context if the image orientation is not already upright.
+    func fixedOrientation() -> UIImage {
+        if imageOrientation == .up { return self }
+        
+        let format = UIGraphicsImageRendererFormat.default()
+        format.scale = self.scale
+        let renderer = UIGraphicsImageRenderer(size: size, format: format)
+        return renderer.image { _ in
+            self.draw(in: CGRect(origin: .zero, size: size))
+        }
+    }
+    
+    /// Returns a new UIImage rotated 90 degrees clockwise by changing its orientation metadata.
+    /// This is an instant metadata operation that does not copy or modify raw pixel buffers.
+    func rotated90Clockwise() -> UIImage? {
+        let newOrientation: UIImage.Orientation
+        switch self.imageOrientation {
+        case .up: newOrientation = .right
+        case .right: newOrientation = .down
+        case .down: newOrientation = .left
+        case .left: newOrientation = .up
+        case .upMirrored: newOrientation = .rightMirrored
+        case .rightMirrored: newOrientation = .downMirrored
+        case .downMirrored: newOrientation = .leftMirrored
+        case .leftMirrored: newOrientation = .upMirrored
+        @unknown default: newOrientation = .right
+        }
+        
+        if let cgImage = self.cgImage {
+            return UIImage(cgImage: cgImage, scale: self.scale, orientation: newOrientation)
+        } else if let ciImage = self.ciImage {
+            return UIImage(ciImage: ciImage, scale: self.scale, orientation: newOrientation)
+        }
+        return nil
+    }
+    
+    /// Downscales the image so its maximum dimension (width or height) does not exceed the specified limit.
+    /// Keeps exact pixel dimensions using 1.0 scale and outputs a normalized (.up) orientation image.
+    func downscaled(toMaxDimension maxDimension: CGFloat) -> UIImage {
+        let size = self.size
+        let maxDim = max(size.width, size.height)
+        if maxDim <= maxDimension {
+            return self
+        }
+        
+        let scale = maxDimension / maxDim
+        let newSize = CGSize(width: size.width * scale, height: size.height * scale)
+        
+        let format = UIGraphicsImageRendererFormat.default()
+        format.scale = 1.0 // Use 1.0 scale to keep exact pixel dimensions
+        let renderer = UIGraphicsImageRenderer(size: newSize, format: format)
+        
+        return renderer.image { _ in
+            self.draw(in: CGRect(origin: .zero, size: newSize))
+        }
+    }
+}
+
+// MARK: - CGImagePropertyOrientation Mapping Helper
+
+extension CGImagePropertyOrientation {
+    
+    /// Maps a `UIImage.Orientation` enum value to its corresponding `CGImagePropertyOrientation` counterpart.
+    init(_ uiOrientation: UIImage.Orientation) {
+        switch uiOrientation {
+        case .up: self = .up
+        case .upMirrored: self = .upMirrored
+        case .down: self = .down
+        case .downMirrored: self = .downMirrored
+        case .leftMirrored: self = .leftMirrored
+        case .right: self = .right
+        case .rightMirrored: self = .rightMirrored
+        case .left: self = .left
+        @unknown default: self = .up
+        }
+    }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cunning_document_scanner
 description: A document scanner plugin for flutter. Scan and crop automatically on iOS and Android.
-version: 2.6.0
+version: 2.7.0
 homepage: https://cunning.biz
 repository: https://github.com/jachzen/cunning_document_scanner
 


### PR DESCRIPTION
This PR adds a manual document cropping view controller in Swift for iOS to un-skew and crop images imported from the gallery, resolving the discrepancy with Android.

Fixes: #149