### PR TITLE
feat(ios): add document image filters to custom cropper (closes #153)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.8.0
+### iOS
+* Added document image filter options (**Original**, **Color**, **Grayscale**, **B&W**) to the custom document cropper (`CunningDocumentCropperViewController`) when importing images from the gallery, achieving feature parity with Android ML Kit (fixes #153).
+
 ## 2.7.0
 ### General
 * Added `CunningDocumentScanner.cleanCache()` to clear temporary scanned images and generated PDF files from local storage.

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/CunningDocumentCropperViewController.swift
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/CunningDocumentCropperViewController.swift
@@ -12,6 +12,32 @@ protocol CunningDocumentCropperDelegate: AnyObject {
     func didCancelCropping()
 }
 
+/// Available image filter modes for scanned document pages.
+enum DocumentFilter: Int, CaseIterable {
+    case original = 0
+    case color = 1
+    case grayscale = 2
+    case blackAndWhite = 3
+    
+    var titleKey: String {
+        switch self {
+        case .original: return "cunning_document_scanner_filter_original"
+        case .color: return "cunning_document_scanner_filter_color"
+        case .grayscale: return "cunning_document_scanner_filter_grayscale"
+        case .blackAndWhite: return "cunning_document_scanner_filter_bw"
+        }
+    }
+    
+    var defaultTitle: String {
+        switch self {
+        case .original: return "Original"
+        case .color: return "Color"
+        case .grayscale: return "Grayscale"
+        case .blackAndWhite: return "B&W"
+        }
+    }
+}
+
 /// View controller that provides an interactive multi-page document cropping interface.
 /// It displays selected images and overlays draggable handles to correct perspective skewing.
 class CunningDocumentCropperViewController: UIViewController {
@@ -36,6 +62,12 @@ class CunningDocumentCropperViewController: UIViewController {
     
     /// The top navigation bar view.
     private let topBar = UIView()
+    
+    /// The filter bar container view.
+    private let filterBar = UIView()
+    
+    /// The segmented control for selecting image filters.
+    private let filterSegmentedControl = UISegmentedControl()
     
     /// The bottom control bar view.
     private let bottomBar = UIView()
@@ -72,6 +104,9 @@ class CunningDocumentCropperViewController: UIViewController {
     /// A list mapping page indexes to their last saved/detected cropping coordinates.
     private var savedCoordinates: [PageCoordinates?] = []
     
+    /// The selected filter for each page index.
+    private var selectedFilters: [DocumentFilter] = []
+    
     /// Indicates whether the initial corner points have been set up for the current page.
     private var hasSetupPoints = false
     
@@ -97,8 +132,9 @@ class CunningDocumentCropperViewController: UIViewController {
     init(images: [UIImage], localize: @escaping (String, String) -> String) {
         self.localize = localize
         self.images = images
-        super.init(nibName: nil, bundle: nil)
         self.savedCoordinates = Array(repeating: nil, count: images.count)
+        self.selectedFilters = Array(repeating: .original, count: images.count)
+        super.init(nibName: nil, bundle: nil)
     }
     
     override var preferredStatusBarStyle: UIStatusBarStyle {
@@ -163,6 +199,22 @@ class CunningDocumentCropperViewController: UIViewController {
         titleLabel.textAlignment = .center
         topBar.addSubview(titleLabel)
         
+        // Filter Bar configuration
+        filterBar.backgroundColor = UIColor.black.withAlphaComponent(0.6)
+        view.addSubview(filterBar)
+        
+        filterSegmentedControl.removeAllSegments()
+        for (index, filter) in DocumentFilter.allCases.enumerated() {
+            let title = localize(filter.titleKey, filter.defaultTitle)
+            filterSegmentedControl.insertSegment(withTitle: title, at: index, animated: false)
+        }
+        filterSegmentedControl.selectedSegmentIndex = 0
+        filterSegmentedControl.selectedSegmentTintColor = .systemBlue
+        filterSegmentedControl.setTitleTextAttributes([.foregroundColor: UIColor.white], for: .selected)
+        filterSegmentedControl.setTitleTextAttributes([.foregroundColor: UIColor.lightGray], for: .normal)
+        filterSegmentedControl.addTarget(self, action: #selector(handleFilterChanged), for: .valueChanged)
+        filterBar.addSubview(filterSegmentedControl)
+        
         // Bottom Bar configuration
         bottomBar.backgroundColor = UIColor.black.withAlphaComponent(0.6)
         view.addSubview(bottomBar)
@@ -207,6 +259,8 @@ class CunningDocumentCropperViewController: UIViewController {
         imageView.translatesAutoresizingMaskIntoConstraints = false
         overlayView.translatesAutoresizingMaskIntoConstraints = false
         topBar.translatesAutoresizingMaskIntoConstraints = false
+        filterBar.translatesAutoresizingMaskIntoConstraints = false
+        filterSegmentedControl.translatesAutoresizingMaskIntoConstraints = false
         bottomBar.translatesAutoresizingMaskIntoConstraints = false
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
         cancelButton.translatesAutoresizingMaskIntoConstraints = false
@@ -258,9 +312,20 @@ class CunningDocumentCropperViewController: UIViewController {
             rotateButton.widthAnchor.constraint(equalToConstant: 44),
             rotateButton.heightAnchor.constraint(equalToConstant: 44),
             
-            // Image View (fills space between top and bottom bar)
+            // Filter Bar
+            filterBar.bottomAnchor.constraint(equalTo: bottomBar.topAnchor),
+            filterBar.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            filterBar.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            filterBar.heightAnchor.constraint(equalToConstant: 44),
+            
+            filterSegmentedControl.centerXAnchor.constraint(equalTo: filterBar.centerXAnchor),
+            filterSegmentedControl.centerYAnchor.constraint(equalTo: filterBar.centerYAnchor),
+            filterSegmentedControl.leadingAnchor.constraint(equalTo: filterBar.leadingAnchor, constant: 15),
+            filterSegmentedControl.trailingAnchor.constraint(equalTo: filterBar.trailingAnchor, constant: -15),
+            
+            // Image View (fills space between top and filter bar)
             imageView.topAnchor.constraint(equalTo: topBar.bottomAnchor),
-            imageView.bottomAnchor.constraint(equalTo: bottomBar.topAnchor),
+            imageView.bottomAnchor.constraint(equalTo: filterBar.topAnchor),
             imageView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             imageView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             
@@ -270,6 +335,23 @@ class CunningDocumentCropperViewController: UIViewController {
             overlayView.leadingAnchor.constraint(equalTo: imageView.leadingAnchor),
             overlayView.trailingAnchor.constraint(equalTo: imageView.trailingAnchor)
         ])
+    }
+    
+    /// Responds to changes in the filter segmented control.
+    @objc private func handleFilterChanged(_ sender: UISegmentedControl) {
+        guard currentIndex < images.count, let currentImage = self.currentNormalizedImage else { return }
+        guard let filter = DocumentFilter(rawValue: sender.selectedSegmentIndex) else { return }
+        selectedFilters[currentIndex] = filter
+        
+        let filterToApply = filter
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            guard let self = self else { return }
+            let filtered = self.applyFilter(filterToApply, to: currentImage)
+            DispatchQueue.main.async {
+                guard self.currentIndex < self.images.count else { return }
+                self.imageView.image = filtered
+            }
+        }
     }
     
     /// Loads and processes the image corresponding to the current index.
@@ -285,6 +367,7 @@ class CunningDocumentCropperViewController: UIViewController {
         rotateButton.isEnabled = false
         cancelButton.isEnabled = false
         backButton.isEnabled = false
+        filterSegmentedControl.isEnabled = false
         
         // Update Title and Done Button Label
         let pageNum = currentIndex + 1
@@ -299,8 +382,13 @@ class CunningDocumentCropperViewController: UIViewController {
         doneButton.tintColor = .white
         doneButton.backgroundColor = .systemBlue
         
+        // Restore selected filter segment index
+        filterSegmentedControl.selectedSegmentIndex = selectedFilters[currentIndex].rawValue
+        
         // Show/hide back button based on page index
         backButton.isHidden = (currentIndex == 0)
+        
+        let currentFilter = selectedFilters[currentIndex]
         
         // Perform fixedOrientation on a background thread with an autoreleasepool to save memory
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
@@ -322,17 +410,20 @@ class CunningDocumentCropperViewController: UIViewController {
                     self.doneButton.isEnabled = true
                     self.rotateButton.isEnabled = true
                     self.cancelButton.isEnabled = true
+                    self.filterSegmentedControl.isEnabled = true
                     self.backButton.isEnabled = !self.backButton.isHidden
                     return
                 }
                 
                 self.currentNormalizedImage = resolvedImage
-                self.imageView.image = resolvedImage
+                let filteredPreview = self.applyFilter(currentFilter, to: resolvedImage)
+                self.imageView.image = filteredPreview
                 
                 self.activityIndicator.stopAnimating()
                 self.doneButton.isEnabled = true
                 self.rotateButton.isEnabled = true
                 self.cancelButton.isEnabled = true
+                self.filterSegmentedControl.isEnabled = true
                 self.backButton.isEnabled = !self.backButton.isHidden
                 
                 // Restore coordinates if previously saved, otherwise run auto-detection
@@ -466,7 +557,10 @@ class CunningDocumentCropperViewController: UIViewController {
         doneButton.isEnabled = false
         rotateButton.isEnabled = false
         backButton.isEnabled = false
+        filterSegmentedControl.isEnabled = false
         activityIndicator.startAnimating()
+        
+        let currentFilter = selectedFilters[currentIndex]
         
         // Crop the current image on a background thread
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
@@ -483,22 +577,25 @@ class CunningDocumentCropperViewController: UIViewController {
                 )
             }
             
-            let finalImage: UIImage
+            let baseImage: UIImage
             if let cropped = cropped {
-                finalImage = cropped
+                baseImage = cropped
             } else {
                 // Fallback to original image with orientation fixed/baked in
                 var fixed: UIImage?
                 autoreleasepool {
                     fixed = currentImage.fixedOrientation()
                 }
-                finalImage = fixed ?? currentImage
+                baseImage = fixed ?? currentImage
             }
+            
+            let finalImage = self.applyFilter(currentFilter, to: baseImage)
             
             DispatchQueue.main.async {
                 self.cancelButton.isEnabled = true
                 self.doneButton.isEnabled = true
                 self.rotateButton.isEnabled = true
+                self.filterSegmentedControl.isEnabled = true
                 self.backButton.isEnabled = true
                 self.activityIndicator.stopAnimating()
                 
@@ -522,7 +619,8 @@ class CunningDocumentCropperViewController: UIViewController {
         if let rotated = currentImage.rotated90Clockwise() {
             self.images[currentIndex] = rotated
             self.currentNormalizedImage = rotated
-            self.imageView.image = rotated
+            let currentFilter = self.selectedFilters[self.currentIndex]
+            self.imageView.image = self.applyFilter(currentFilter, to: rotated)
             
             // Rotate the normalized coordinates 90 degrees clockwise:
             // x' = y
@@ -594,5 +692,55 @@ class CunningDocumentCropperViewController: UIViewController {
         guard let cgImage = self.ciContext.createCGImage(outputImage, from: outputImage.extent) else { return nil }
         
         return UIImage(cgImage: cgImage)
+    }
+    
+    /// Applies the requested DocumentFilter to an image using CoreImage filters.
+    private func applyFilter(_ filter: DocumentFilter, to image: UIImage) -> UIImage {
+        guard filter != .original else { return image }
+        guard let ciImage = CIImage(image: image) ?? (image.cgImage != nil ? CIImage(cgImage: image.cgImage!) : nil) else {
+            return image
+        }
+        
+        let outputCIImage: CIImage
+        switch filter {
+        case .original:
+            return image
+        case .color:
+            if let colorFilter = CIFilter(name: "CIColorControls") {
+                colorFilter.setValue(ciImage, forKey: kCIInputImageKey)
+                colorFilter.setValue(1.15, forKey: kCIInputContrastKey)
+                colorFilter.setValue(1.2, forKey: kCIInputSaturationKey)
+                colorFilter.setValue(0.03, forKey: kCIInputBrightnessKey)
+                outputCIImage = colorFilter.outputImage ?? ciImage
+            } else {
+                outputCIImage = ciImage
+            }
+        case .grayscale:
+            if let monoFilter = CIFilter(name: "CIPhotoEffectMono") {
+                monoFilter.setValue(ciImage, forKey: kCIInputImageKey)
+                outputCIImage = monoFilter.outputImage ?? ciImage
+            } else if let colorFilter = CIFilter(name: "CIColorControls") {
+                colorFilter.setValue(ciImage, forKey: kCIInputImageKey)
+                colorFilter.setValue(0.0, forKey: kCIInputSaturationKey)
+                outputCIImage = colorFilter.outputImage ?? ciImage
+            } else {
+                outputCIImage = ciImage
+            }
+        case .blackAndWhite:
+            if let colorFilter = CIFilter(name: "CIColorControls") {
+                colorFilter.setValue(ciImage, forKey: kCIInputImageKey)
+                colorFilter.setValue(0.0, forKey: kCIInputSaturationKey)
+                colorFilter.setValue(1.8, forKey: kCIInputContrastKey)
+                colorFilter.setValue(0.05, forKey: kCIInputBrightnessKey)
+                outputCIImage = colorFilter.outputImage ?? ciImage
+            } else {
+                outputCIImage = ciImage
+            }
+        }
+        
+        guard let cgImage = self.ciContext.createCGImage(outputCIImage, from: outputCIImage.extent) else {
+            return image
+        }
+        return UIImage(cgImage: cgImage, scale: image.scale, orientation: image.imageOrientation)
     }
 }

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/ar.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/ar.lproj/Localizable.strings
@@ -5,3 +5,8 @@
 "cunning_document_scanner_discard_title" = "تجاهل التغييرات؟";
 "cunning_document_scanner_discard_message" = "هل أنت متأكد أنك تريد تجاهل تقدمك؟";
 "cunning_document_scanner_discard" = "تجاهل";
+
+"cunning_document_scanner_filter_original" = "الأصلي";
+"cunning_document_scanner_filter_color" = "ألوان";
+"cunning_document_scanner_filter_grayscale" = "تدرج الرمادي";
+"cunning_document_scanner_filter_bw" = "أسود وأبيض";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/ca.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/ca.lproj/Localizable.strings
@@ -5,3 +5,8 @@
 "cunning_document_scanner_discard_title" = "Descartar els canvis?";
 "cunning_document_scanner_discard_message" = "Esteu segur que voleu descartar el vostre progrés?";
 "cunning_document_scanner_discard" = "Descartar";
+
+"cunning_document_scanner_filter_original" = "Original";
+"cunning_document_scanner_filter_color" = "Color";
+"cunning_document_scanner_filter_grayscale" = "Escala de grisos";
+"cunning_document_scanner_filter_bw" = "B/N";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/cs.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/cs.lproj/Localizable.strings
@@ -5,3 +5,8 @@
 "cunning_document_scanner_discard_title" = "Zahodit změny?";
 "cunning_document_scanner_discard_message" = "Opravdu chcete zahodit svůj postup?";
 "cunning_document_scanner_discard" = "Zahodit";
+
+"cunning_document_scanner_filter_original" = "Originál";
+"cunning_document_scanner_filter_color" = "Barevně";
+"cunning_document_scanner_filter_grayscale" = "Stupně šedi";
+"cunning_document_scanner_filter_bw" = "ČB";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/da.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/da.lproj/Localizable.strings
@@ -5,3 +5,8 @@
 "cunning_document_scanner_discard_title" = "Kasser ændringer?";
 "cunning_document_scanner_discard_message" = "Er du sikker på, at du vil kassere dit fremskridt?";
 "cunning_document_scanner_discard" = "Kasser";
+
+"cunning_document_scanner_filter_original" = "Original";
+"cunning_document_scanner_filter_color" = "Farve";
+"cunning_document_scanner_filter_grayscale" = "Gråtoner";
+"cunning_document_scanner_filter_bw" = "S/H";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/de.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/de.lproj/Localizable.strings
@@ -5,3 +5,8 @@
 "cunning_document_scanner_discard_title" = "Änderungen verwerfen?";
 "cunning_document_scanner_discard_message" = "Sind Sie sicher, dass Sie Ihren Fortschritt verwerfen möchten?";
 "cunning_document_scanner_discard" = "Verwerfen";
+
+"cunning_document_scanner_filter_original" = "Original";
+"cunning_document_scanner_filter_color" = "Farbe";
+"cunning_document_scanner_filter_grayscale" = "Graustufen";
+"cunning_document_scanner_filter_bw" = "S/W";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/el.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/el.lproj/Localizable.strings
@@ -5,3 +5,8 @@
 "cunning_document_scanner_discard_title" = "Απόρριψη αλλαγών;";
 "cunning_document_scanner_discard_message" = "Είστε βέβαιοι ότι θέλετε να απορρίψετε την πρόοδό σας;";
 "cunning_document_scanner_discard" = "Απόρριψη";
+
+"cunning_document_scanner_filter_original" = "Αρχικό";
+"cunning_document_scanner_filter_color" = "Έγχρωμο";
+"cunning_document_scanner_filter_grayscale" = "Κλίμακα γκρι";
+"cunning_document_scanner_filter_bw" = "A/M";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/en.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/en.lproj/Localizable.strings
@@ -5,3 +5,8 @@
 "cunning_document_scanner_discard_title" = "Discard changes?";
 "cunning_document_scanner_discard_message" = "Are you sure you want to discard your progress?";
 "cunning_document_scanner_discard" = "Discard";
+"cunning_document_scanner_filter_original" = "Original";
+"cunning_document_scanner_filter_color" = "Color";
+"cunning_document_scanner_filter_grayscale" = "Grayscale";
+"cunning_document_scanner_filter_bw" = "B&W";
+

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/es.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/es.lproj/Localizable.strings
@@ -5,3 +5,8 @@
 "cunning_document_scanner_discard_title" = "¿Descartar cambios?";
 "cunning_document_scanner_discard_message" = "¿Está seguro de que desea descartar su progreso?";
 "cunning_document_scanner_discard" = "Descartar";
+"cunning_document_scanner_filter_original" = "Original";
+"cunning_document_scanner_filter_color" = "Color";
+"cunning_document_scanner_filter_grayscale" = "Escala de grises";
+"cunning_document_scanner_filter_bw" = "B/N";
+

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/fi.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/fi.lproj/Localizable.strings
@@ -5,3 +5,8 @@
 "cunning_document_scanner_discard_title" = "Hylätäänkö muutokset?";
 "cunning_document_scanner_discard_message" = "Haluatko varmasti hylätä edistymisesi?";
 "cunning_document_scanner_discard" = "Hylkää";
+
+"cunning_document_scanner_filter_original" = "Alkuperäinen";
+"cunning_document_scanner_filter_color" = "Väri";
+"cunning_document_scanner_filter_grayscale" = "Harmaasävy";
+"cunning_document_scanner_filter_bw" = "M/V";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/fr.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/fr.lproj/Localizable.strings
@@ -5,3 +5,8 @@
 "cunning_document_scanner_discard_title" = "Abandonner les modifications ?";
 "cunning_document_scanner_discard_message" = "Voulez-vous vraiment abandonner votre progression ?";
 "cunning_document_scanner_discard" = "Abandonner";
+
+"cunning_document_scanner_filter_original" = "Original";
+"cunning_document_scanner_filter_color" = "Couleur";
+"cunning_document_scanner_filter_grayscale" = "Niveaux de gris";
+"cunning_document_scanner_filter_bw" = "N&B";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/he.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/he.lproj/Localizable.strings
@@ -5,3 +5,8 @@
 "cunning_document_scanner_discard_title" = "למחוק את השינויים?";
 "cunning_document_scanner_discard_message" = "האם אתה בטוח שברצונך למחוק את ההתקדמות שלך?";
 "cunning_document_scanner_discard" = "למחוק";
+
+"cunning_document_scanner_filter_original" = "מקורי";
+"cunning_document_scanner_filter_color" = "צבע";
+"cunning_document_scanner_filter_grayscale" = "גווני אפור";
+"cunning_document_scanner_filter_bw" = "שחור-לבן";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/hi.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/hi.lproj/Localizable.strings
@@ -5,3 +5,8 @@
 "cunning_document_scanner_discard_title" = "बदलावों को खारिज करें?";
 "cunning_document_scanner_discard_message" = "क्या आप वाकई अपनी प्रगति को खारिज करना चाहते हैं?";
 "cunning_document_scanner_discard" = "खारिज करें";
+
+"cunning_document_scanner_filter_original" = "मूल";
+"cunning_document_scanner_filter_color" = "रंग";
+"cunning_document_scanner_filter_grayscale" = "ग्रेस्केल";
+"cunning_document_scanner_filter_bw" = "श्वेत-श्याम";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/id.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/id.lproj/Localizable.strings
@@ -5,3 +5,8 @@
 "cunning_document_scanner_discard_title" = "Buang perubahan?";
 "cunning_document_scanner_discard_message" = "Apakah Anda yakin ingin membuang kemajuan Anda?";
 "cunning_document_scanner_discard" = "Buang";
+
+"cunning_document_scanner_filter_original" = "Asli";
+"cunning_document_scanner_filter_color" = "Warna";
+"cunning_document_scanner_filter_grayscale" = "Skala Abu-abu";
+"cunning_document_scanner_filter_bw" = "Hitam Putih";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/it.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/it.lproj/Localizable.strings
@@ -5,3 +5,8 @@
 "cunning_document_scanner_discard_title" = "Annullare le modifiche?";
 "cunning_document_scanner_discard_message" = "Sei sicuro di voler annullare i tuoi progressi?";
 "cunning_document_scanner_discard" = "Annulla";
+
+"cunning_document_scanner_filter_original" = "Originale";
+"cunning_document_scanner_filter_color" = "Colore";
+"cunning_document_scanner_filter_grayscale" = "Scala di grigi";
+"cunning_document_scanner_filter_bw" = "B/N";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/ja.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/ja.lproj/Localizable.strings
@@ -5,3 +5,8 @@
 "cunning_document_scanner_discard_title" = "変更を破棄しますか？";
 "cunning_document_scanner_discard_message" = "これまでの進行状況を破棄してもよろしいですか？";
 "cunning_document_scanner_discard" = "破棄";
+
+"cunning_document_scanner_filter_original" = "オリジナル";
+"cunning_document_scanner_filter_color" = "カラー";
+"cunning_document_scanner_filter_grayscale" = "グレースケール";
+"cunning_document_scanner_filter_bw" = "白黒";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/ko.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/ko.lproj/Localizable.strings
@@ -5,3 +5,8 @@
 "cunning_document_scanner_discard_title" = "변경사항을 취소하시겠습니까?";
 "cunning_document_scanner_discard_message" = "지금까지의 진행 상황을 취소하시겠습니까?";
 "cunning_document_scanner_discard" = "취소";
+
+"cunning_document_scanner_filter_original" = "원본";
+"cunning_document_scanner_filter_color" = "컬러";
+"cunning_document_scanner_filter_grayscale" = "회색조";
+"cunning_document_scanner_filter_bw" = "흑백";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/nb.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/nb.lproj/Localizable.strings
@@ -5,3 +5,8 @@
 "cunning_document_scanner_discard_title" = "Forkast endringer?";
 "cunning_document_scanner_discard_message" = "Er du sikker på at du vil forkaste fremgangen din?";
 "cunning_document_scanner_discard" = "Forkast";
+
+"cunning_document_scanner_filter_original" = "Original";
+"cunning_document_scanner_filter_color" = "Farge";
+"cunning_document_scanner_filter_grayscale" = "Gråtone";
+"cunning_document_scanner_filter_bw" = "S/H";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/nl.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/nl.lproj/Localizable.strings
@@ -5,3 +5,8 @@
 "cunning_document_scanner_discard_title" = "Wijzigingen weggooien?";
 "cunning_document_scanner_discard_message" = "Weet u zeker dat u uw voortgang wilt weggooien?";
 "cunning_document_scanner_discard" = "Weggooien";
+
+"cunning_document_scanner_filter_original" = "Origineel";
+"cunning_document_scanner_filter_color" = "Kleur";
+"cunning_document_scanner_filter_grayscale" = "Grijswaarden";
+"cunning_document_scanner_filter_bw" = "Z/W";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/pl.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/pl.lproj/Localizable.strings
@@ -5,3 +5,8 @@
 "cunning_document_scanner_discard_title" = "Odrzucić zmiany?";
 "cunning_document_scanner_discard_message" = "Czy na pewno chcesz odrzucić swoje postępy?";
 "cunning_document_scanner_discard" = "Odrzuć";
+
+"cunning_document_scanner_filter_original" = "Oryginał";
+"cunning_document_scanner_filter_color" = "Kolor";
+"cunning_document_scanner_filter_grayscale" = "Odcienie szarości";
+"cunning_document_scanner_filter_bw" = "Cz/B";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/pt.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/pt.lproj/Localizable.strings
@@ -5,3 +5,8 @@
 "cunning_document_scanner_discard_title" = "Descartar alterações?";
 "cunning_document_scanner_discard_message" = "Tem a certeza de que deseja descartar o seu progresso?";
 "cunning_document_scanner_discard" = "Descartar";
+
+"cunning_document_scanner_filter_original" = "Original";
+"cunning_document_scanner_filter_color" = "Cor";
+"cunning_document_scanner_filter_grayscale" = "Escala de cinza";
+"cunning_document_scanner_filter_bw" = "P/B";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/ro.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/ro.lproj/Localizable.strings
@@ -5,3 +5,8 @@
 "cunning_document_scanner_discard_title" = "Renunțați la modificări?";
 "cunning_document_scanner_discard_message" = "Sigur doriți să renunțați la progresul realizat?";
 "cunning_document_scanner_discard" = "Renunțare";
+
+"cunning_document_scanner_filter_original" = "Original";
+"cunning_document_scanner_filter_color" = "Culoare";
+"cunning_document_scanner_filter_grayscale" = "Tonuri de gri";
+"cunning_document_scanner_filter_bw" = "A/N";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/ru.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/ru.lproj/Localizable.strings
@@ -5,3 +5,8 @@
 "cunning_document_scanner_discard_title" = "Сбросить изменения?";
 "cunning_document_scanner_discard_message" = "Вы уверены, что хотите сбросить свой прогресс?";
 "cunning_document_scanner_discard" = "Сбросить";
+
+"cunning_document_scanner_filter_original" = "Оригинал";
+"cunning_document_scanner_filter_color" = "Цвет";
+"cunning_document_scanner_filter_grayscale" = "Оттенки серого";
+"cunning_document_scanner_filter_bw" = "Ч/Б";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/sv.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/sv.lproj/Localizable.strings
@@ -5,3 +5,8 @@
 "cunning_document_scanner_discard_title" = "Forkasta ändringar?";
 "cunning_document_scanner_discard_message" = "Är du säker på att du vil forkasta dina framsteg?";
 "cunning_document_scanner_discard" = "Forkasta";
+
+"cunning_document_scanner_filter_original" = "Original";
+"cunning_document_scanner_filter_color" = "Färg";
+"cunning_document_scanner_filter_grayscale" = "Gråskala";
+"cunning_document_scanner_filter_bw" = "S/V";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/th.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/th.lproj/Localizable.strings
@@ -5,3 +5,8 @@
 "cunning_document_scanner_discard_title" = "ละทิ้งการเปลี่ยนแปลง?";
 "cunning_document_scanner_discard_message" = "คุณแน่ใจหรือไม่ว่าต้องการละทิ้งความคืบหน้าของคุณ?";
 "cunning_document_scanner_discard" = "ละทิ้ง";
+
+"cunning_document_scanner_filter_original" = "ต้นฉบับ";
+"cunning_document_scanner_filter_color" = "สี";
+"cunning_document_scanner_filter_grayscale" = "ขาวดำ";
+"cunning_document_scanner_filter_bw" = "ขาวดำ";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/tr.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/tr.lproj/Localizable.strings
@@ -5,3 +5,8 @@
 "cunning_document_scanner_discard_title" = "Değişiklikleri iptal et?";
 "cunning_document_scanner_discard_message" = "İlerlemenizi iptal etmek istediğinizden emin misiniz?";
 "cunning_document_scanner_discard" = "İptal et";
+
+"cunning_document_scanner_filter_original" = "Orijinal";
+"cunning_document_scanner_filter_color" = "Renkli";
+"cunning_document_scanner_filter_grayscale" = "Gri Tonlama";
+"cunning_document_scanner_filter_bw" = "S/B";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/uk.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/uk.lproj/Localizable.strings
@@ -5,3 +5,8 @@
 "cunning_document_scanner_discard_title" = "Скасувати зміни?";
 "cunning_document_scanner_discard_message" = "Ви впевнені, що хочете скасувати свій прогрес?";
 "cunning_document_scanner_discard" = "Скасувати";
+
+"cunning_document_scanner_filter_original" = "Оригінал";
+"cunning_document_scanner_filter_color" = "Колір";
+"cunning_document_scanner_filter_grayscale" = "Відтінки сірого";
+"cunning_document_scanner_filter_bw" = "Ч/Б";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/vi.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/vi.lproj/Localizable.strings
@@ -5,3 +5,8 @@
 "cunning_document_scanner_discard_title" = "Hủy bỏ các thay đổi?";
 "cunning_document_scanner_discard_message" = "Bạn có chắc chắn muốn hủy bỏ tiến trình của mình không?";
 "cunning_document_scanner_discard" = "Hủy bỏ";
+
+"cunning_document_scanner_filter_original" = "Gốc";
+"cunning_document_scanner_filter_color" = "Màu";
+"cunning_document_scanner_filter_grayscale" = "Mức xám";
+"cunning_document_scanner_filter_bw" = "Trắng đen";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/zh-Hans.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/zh-Hans.lproj/Localizable.strings
@@ -5,3 +5,8 @@
 "cunning_document_scanner_discard_title" = "放弃更改吗？";
 "cunning_document_scanner_discard_message" = "您确定要放弃当前的进度吗？";
 "cunning_document_scanner_discard" = "放弃";
+
+"cunning_document_scanner_filter_original" = "原图";
+"cunning_document_scanner_filter_color" = "彩色";
+"cunning_document_scanner_filter_grayscale" = "灰度";
+"cunning_document_scanner_filter_bw" = "黑白";

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/zh-Hant.lproj/Localizable.strings
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/Resources/zh-Hant.lproj/Localizable.strings
@@ -5,3 +5,8 @@
 "cunning_document_scanner_discard_title" = "放棄變更嗎？";
 "cunning_document_scanner_discard_message" = "您確定要放棄目前的進度嗎？";
 "cunning_document_scanner_discard" = "放棄";
+
+"cunning_document_scanner_filter_original" = "原圖";
+"cunning_document_scanner_filter_color" = "彩色";
+"cunning_document_scanner_filter_grayscale" = "灰階";
+"cunning_document_scanner_filter_bw" = "黑白";

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cunning_document_scanner
 description: A document scanner plugin for flutter. Scan and crop automatically on iOS and Android.
-version: 2.7.0
+version: 2.8.0
 homepage: https://cunning.biz
 repository: https://github.com/jachzen/cunning_document_scanner
 


### PR DESCRIPTION
## Description
Adds document image filter options (**Original**, **Color**, **Grayscale**, **B&W**) to the iOS custom document cropper (`CunningDocumentCropperViewController`) when scanning images from the gallery, achieving feature parity with Android ML Kit.

## Key Changes
- **`DocumentFilter` Enum**: Defined 4 filter modes (`original`, `color`, `grayscale`, `blackAndWhite`).
- **Filter Selector UI**: Added a `UISegmentedControl` filter bar in `CunningDocumentCropperViewController`.
- **CoreImage Processing**: Live preview filtering + perspective-corrected output filtering.
- **State Management**: Saved selected filters per page index so navigating back/forth or rotating preserves filter selections.
- **Multi-language Support**: Added native localized filter titles to all 29 `.lproj` localization files (`en`, `es`, `de`, `fr`, `it`, `pt`, `ja`, `zh-Hans`, etc.).

Closes #153