### PR TITLE
Fix result callback leaks that could lock the scanner, and cleanCache's Activity requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 * **`IosScannerOptions` is no longer a `const` constructor.** It now validates `jpgCompressionQuality` and throws an `ArgumentError` for values outside 0.0 - 1.0.
 
 ### Fixed
+* **The scanner could be locked out for the rest of the process on iPad.** The `cameraAndGallery` action sheet is a popover there, and dismissing it by tapping outside could leave the pending result callback stranded, after which every later call failed with `ALREADY_ACTIVE`. The same happened when no view controller was available to present from. Dismissal by gesture is now treated as a cancellation, and a missing presenter fails immediately with `NO_VIEW_CONTROLLER` rather than consuming the call.
+* **`cleanCache()` no longer requires an attached `Activity` on Android.** It only ever needed a `Context`, so cleaning at startup — before any `Activity` is attached — used to fail with `NO_ACTIVITY` for no technical reason.
 * **A `restricted` camera authorization was ignored on iOS.** Devices under parental controls or an MDM policy report `restricted`, which the Dart-side check did not treat as a refusal, so the scanner opened a camera the user could never grant access to. The native check covers it.
 * **The camera permission was requested even for gallery-only flows.** `ScannerSource.gallery` uses the out-of-process system photo picker, which needs no permission; it no longer prompts for anything.
 * **`cleanCache()` could delete host application data.** On iOS it removed every `.pdf`, `.jpg` and `.png` in the app's `Documents` directory; on Android it matched by file extension in `cacheDir` and the pictures directory. Both now delete only files the plugin itself wrote, identified by the `DOCUMENT_SCAN_` prefix and the private storage directory.

--- a/README.md
+++ b/README.md
@@ -16,11 +16,12 @@ Cunning Document Scanner is a Flutter-based document scanner application that en
 ## Key Features
 
 - Fast and easy document scanning.
-- Conversion of document images into digital files.
+- Conversion of document images into digital files, including direct PDF export.
 - Support for both Android and iOS platforms.
 - Minimum requirements: API 21 on Android, iOS 13 on iOS.
-- Limit the number of scannable files on Android.
-- Allows selection of images from the gallery on Android.
+- Limit the number of scanned pages on both platforms.
+- Import images from the gallery on both platforms, with manual cropping.
+- No third-party runtime dependencies.
 
 A state of the art document scanner with automatic cropping function.
 

--- a/android/src/main/kotlin/biz/cunning/cunning_document_scanner/CunningDocumentScannerPlugin.kt
+++ b/android/src/main/kotlin/biz/cunning/cunning_document_scanner/CunningDocumentScannerPlugin.kt
@@ -3,6 +3,7 @@ package biz.cunning.cunning_document_scanner
 import android.app.Activity
 import android.content.ActivityNotFoundException
 import android.content.ClipData
+import android.content.Context
 import android.content.Intent
 import android.content.IntentSender
 import android.net.Uri
@@ -51,6 +52,10 @@ class CunningDocumentScannerPlugin :
     // / The current Android activity instance, or null while detached.
     private var activity: Activity? = null
 
+    // / Application context, available for as long as the plugin is attached to the engine.
+    // / Used for work that needs no Activity, so it keeps working while detached.
+    private var applicationContext: Context? = null
+
     // / The MethodChannel that handles communication between Flutter and native Android.
     private lateinit var channel: MethodChannel
 
@@ -66,6 +71,7 @@ class CunningDocumentScannerPlugin :
 
     // / Called when the plugin is attached to the Flutter Engine.
     override fun onAttachedToEngine(flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
+        applicationContext = flutterPluginBinding.applicationContext
         channel = MethodChannel(flutterPluginBinding.binaryMessenger, "cunning_document_scanner")
         channel.setMethodCallHandler(this)
     }
@@ -138,15 +144,18 @@ class CunningDocumentScannerPlugin :
     // / `cacheDir` and the pictures directory are shared with the host application, and
     // / deleting every image or PDF found there would destroy the host application's data.
     private fun cleanCache(result: Result) {
-        val currentActivity = activity
-        if (currentActivity == null) {
-            result.error("NO_ACTIVITY", "Plugin is not attached to an Activity", null)
+        // Only Context methods are needed here, so the application context is used rather
+        // than the Activity: cleaning the cache on startup, before any Activity is
+        // attached, is a legitimate call and used to fail for no technical reason.
+        val context = applicationContext
+        if (context == null) {
+            result.error("NO_CONTEXT", "Plugin is not attached to the Flutter engine", null)
             return
         }
 
         try {
-            val picturesDir = currentActivity.getExternalFilesDir(android.os.Environment.DIRECTORY_PICTURES)
-            listOfNotNull(picturesDir, currentActivity.cacheDir).forEach { dir ->
+            val picturesDir = context.getExternalFilesDir(android.os.Environment.DIRECTORY_PICTURES)
+            listOfNotNull(picturesDir, context.cacheDir).forEach { dir ->
                 dir.listFiles()?.forEach { file ->
                     if (ScannerArguments.isPluginScanFile(file.name)) {
                         file.delete()
@@ -162,6 +171,7 @@ class CunningDocumentScannerPlugin :
     // / Called when the plugin is detached from the Flutter Engine.
     override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
         channel.setMethodCallHandler(null)
+        applicationContext = null
     }
 
     // / Called when the plugin is attached to the host Activity.

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/CunningDocumentScannerPlugin.swift
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/CunningDocumentScannerPlugin.swift
@@ -73,8 +73,18 @@ public class CunningDocumentScannerPlugin: NSObject,
             return
         }
 
+        // Without a presenter nothing can be shown, and the result callback would be
+        // stored with no flow left to release it, locking out every later call.
+        guard let presentedVC = rootViewController else {
+            result(FlutterError(
+                code: "NO_VIEW_CONTROLLER",
+                message: "No view controller available to present the scanner",
+                details: nil
+            ))
+            return
+        }
+
         scannerOptions = CunningScannerOptions.fromArguments(args: call.arguments)
-        let presentedVC = rootViewController
         resultChannel = result
 
         switch scannerOptions.scannerSource {
@@ -110,14 +120,21 @@ public class CunningDocumentScannerPlugin: NSObject,
             
             if UIDevice.current.userInterfaceIdiom == .pad,
                let popoverController = alertController.popoverPresentationController {
-                popoverController.sourceView = presentedVC?.view
-                let midX = presentedVC?.view.bounds.midX ?? 0
-                let midY = presentedVC?.view.bounds.midY ?? 0
+                popoverController.sourceView = presentedVC.view
+                let midX = presentedVC.view.bounds.midX
+                let midY = presentedVC.view.bounds.midY
                 popoverController.sourceRect = CGRect(x: midX, y: midY, width: 0, height: 0)
                 popoverController.permittedArrowDirections = []
             }
-            
-            presentedVC?.present(alertController, animated: true)
+
+            // On iPad the sheet is a popover, which the user can dismiss by tapping outside
+            // without the cancel action ever running. That would strand the result callback
+            // and, because a second call is rejected as ALREADY_ACTIVE, lock the plugin for
+            // the rest of the process. The delegate only fires for user-driven dismissals,
+            // so choosing Camera or Gallery does not trigger it.
+            alertController.presentationController?.delegate = self
+
+            presentedVC.present(alertController, animated: true)
         }
     }
 
@@ -162,7 +179,7 @@ public class CunningDocumentScannerPlugin: NSObject,
     }
 
     /// Launches the native system document camera (VNDocumentCameraViewController).
-    func openCamera(from presentedVC: UIViewController?) {
+    func openCamera(from presentedVC: UIViewController) {
         withCameraAccess { [weak self] in
             guard let self = self else { return }
 
@@ -175,25 +192,28 @@ public class CunningDocumentScannerPlugin: NSObject,
             let controller = VNDocumentCameraViewController()
             controller.delegate = self
             self.presentingController = controller
-            presentedVC?.present(controller, animated: true)
+            presentedVC.present(controller, animated: true)
         }
     }
 
     /// Launches the photo picker (PHPickerViewController on iOS 14+, fallback to UIImagePickerController).
-    func openGallery(from presentedVC: UIViewController?) {
+    func openGallery(from presentedVC: UIViewController) {
         if #available(iOS 14.0, *) {
             var configuration = PHPickerConfiguration()
             configuration.filter = .images
             configuration.selectionLimit = scannerOptions.noOfPages
-            
+
             let picker = PHPickerViewController(configuration: configuration)
             picker.delegate = self
-            presentedVC?.present(picker, animated: true)
+            presentedVC.present(picker, animated: true)
         } else {
             let picker = UIImagePickerController()
             picker.sourceType = .photoLibrary
             picker.delegate = self
-            presentedVC?.present(picker, animated: true)
+            // Sheet-style presentation lets the user swipe this picker away without
+            // `imagePickerControllerDidCancel` running, which would strand the result.
+            picker.modalPresentationStyle = .fullScreen
+            presentedVC.present(picker, animated: true)
         }
     }
 
@@ -443,6 +463,20 @@ extension CunningDocumentScannerPlugin: PHPickerViewControllerDelegate {
                 }
             }
         }
+    }
+}
+
+// MARK: - UIAdaptivePresentationControllerDelegate
+
+extension CunningDocumentScannerPlugin: UIAdaptivePresentationControllerDelegate {
+
+    /// Treats a swipe-away or tap-outside dismissal as a cancellation.
+    ///
+    /// UIKit only calls this for user-driven dismissals, never for the programmatic
+    /// dismissal that follows tapping an action, so the camera and gallery choices are
+    /// unaffected. `finish` is a no-op once the result has already been delivered.
+    public func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
+        finish(nil)
     }
 }
 


### PR DESCRIPTION
Pre-release pass over 3.0.0. The first fix is a regression introduced by that release, so it should not ship without it.

## The scanner could lock itself out for the rest of the process (iOS)

3.0.0 started rejecting a second concurrent `getPictures()` with `ALREADY_ACTIVE`, which is correct — but it raised the cost of any path that stores the result callback and then fails to release it. What used to be one hung `Future` became a scanner that stays unusable until the app restarts.

Three such paths existed:

- **iPad popover.** `ScannerSource.cameraAndGallery` presents an action sheet, which on iPad is a popover the user can dismiss by tapping outside — potentially without the cancel action running.
- **No root view controller.** `presentedVC?.present(...)` silently did nothing, after the callback had already been stored.
- **Legacy `UIImagePickerController`** (iOS 13) is presented as a sheet and can be swiped away without `imagePickerControllerDidCancel` firing.

Fixed by treating a gesture dismissal as cancellation through `UIAdaptivePresentationControllerDelegate`, failing up front with `NO_VIEW_CONTROLLER` when there is nothing to present from, and presenting the legacy picker full screen.

UIKit only calls `presentationControllerDidDismiss` for user-driven dismissals, never for the programmatic dismissal that follows tapping an action, so choosing Camera or Gallery is unaffected. `finish` is already idempotent, so a cancel action that *does* run makes the delegate call a no-op.

## `cleanCache()` no longer needs an Activity (Android)

It returned `NO_ACTIVITY` when the plugin was detached, but only ever called `getExternalFilesDir` and `cacheDir` — both `Context` methods. Cleaning the cache at startup, before any Activity is attached, is a legitimate call that failed for no technical reason. It now uses the application context held since `onAttachedToEngine`.

## Also

README's feature list still described gallery import and page limits as Android-only; both are cross-platform as of 3.0.0, and the plugin now has no third-party runtime dependencies.

## Considered and rejected

- **Bumping the plugin's `compileSdk` from 34 to 36.** Justified only as tidiness, with no concrete problem behind it, so it stays at 34.
- **Adding a `.pubignore`** to keep `test/` and `tool/` out of the published archive. A `.pubignore` *replaces* `.gitignore` rather than extending it, so doing this correctly means duplicating every root ignore rule and keeping the two files in sync forever. The dry-run caught the consequence of getting it wrong: the archive went from 114 KB to **27 MB**, with `build/` included. Not worth it to save 15 KB.

## Verification

`dart format`, `flutter analyze` and 27 tests pass, the version check is green, and `flutter pub publish --dry-run` reports 0 warnings at 115 KB (the only warning shown locally was uncommitted files).

As with 3.0.0, the Swift and Kotlin changes are not compiled locally — no Xcode or JDK available — so this PR's CI is their first real build.
