### PR TITLE
fix(ios): stop the Camera/Gallery action sheet from dropping the scan result

### DIFF
--- a/ios/.gitignore
+++ b/ios/.gitignore
@@ -9,6 +9,7 @@ profile
 
 DerivedData/
 build/
+.build/
 GeneratedPluginRegistrant.h
 GeneratedPluginRegistrant.m
 

--- a/ios/cunning_document_scanner/Sources/cunning_document_scanner/CunningDocumentScannerPlugin.swift
+++ b/ios/cunning_document_scanner/Sources/cunning_document_scanner/CunningDocumentScannerPlugin.swift
@@ -33,6 +33,13 @@ public class CunningDocumentScannerPlugin: NSObject,
     /// The options passed from the Dart/Flutter side.
     var scannerOptions = CunningScannerOptions()
 
+    /// Set right before the Camera or Gallery action sheet entries open their own flow.
+    ///
+    /// UIKit calls `presentationControllerDidDismiss` for that dismissal too, not only for a
+    /// user tapping outside/swiping the sheet away, so this distinguishes the two: the delegate
+    /// clears it and ignores the callback when set, otherwise it treats the dismissal as a cancel.
+    private var isHandlingAlertAction = false
+
     /// Resolves the current visible or root UIViewController on the key window.
     var rootViewController: UIViewController? {
         let keyWindow = UIApplication.shared.connectedScenes
@@ -100,11 +107,13 @@ public class CunningDocumentScannerPlugin: NSObject,
             alertController.view.tintColor = .systemBlue
             
             let cameraAction = UIAlertAction(title: labelCamera, style: .default) { _ in
+                self.isHandlingAlertAction = true
                 self.openCamera(from: presentedVC)
             }
             cameraAction.setValue(UIColor.systemBlue, forKey: "titleTextColor")
 
             let galleryAction = UIAlertAction(title: labelGallery, style: .default) { _ in
+                self.isHandlingAlertAction = true
                 self.openGallery(from: presentedVC)
             }
             galleryAction.setValue(UIColor.systemBlue, forKey: "titleTextColor")
@@ -130,8 +139,11 @@ public class CunningDocumentScannerPlugin: NSObject,
             // On iPad the sheet is a popover, which the user can dismiss by tapping outside
             // without the cancel action ever running. That would strand the result callback
             // and, because a second call is rejected as ALREADY_ACTIVE, lock the plugin for
-            // the rest of the process. The delegate only fires for user-driven dismissals,
-            // so choosing Camera or Gallery does not trigger it.
+            // the rest of the process. UIKit also invokes this delegate for the dismissal that
+            // follows choosing Camera or Gallery, not only for a tap-outside/swipe dismissal, so
+            // `isHandlingAlertAction` distinguishes the two: it is set right before those actions
+            // present their own flow, and checked (then cleared) here so that legitimate case is
+            // ignored while a real user-driven dismissal still finishes with `nil`.
             alertController.presentationController?.delegate = self
 
             presentedVC.present(alertController, animated: true)
@@ -472,10 +484,14 @@ extension CunningDocumentScannerPlugin: UIAdaptivePresentationControllerDelegate
 
     /// Treats a swipe-away or tap-outside dismissal as a cancellation.
     ///
-    /// UIKit only calls this for user-driven dismissals, never for the programmatic
-    /// dismissal that follows tapping an action, so the camera and gallery choices are
-    /// unaffected. `finish` is a no-op once the result has already been delivered.
+    /// UIKit calls this both for that gesture-driven dismissal and for the one that follows
+    /// tapping Camera or Gallery, so `isHandlingAlertAction` is checked to ignore the latter.
+    /// `finish` is a no-op once the result has already been delivered.
     public func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
+        if isHandlingAlertAction {
+            isHandlingAlertAction = false
+            return
+        }
         finish(nil)
     }
 }


### PR DESCRIPTION
## Summary
- Selecting Camera or Gallery from the `cameraAndGallery` action sheet on iOS dismisses that sheet, and UIKit calls `presentationControllerDidDismiss` for that dismissal too, not only for a tap-outside/swipe-away gesture. That delegate treated any dismissal as a cancellation, so it finished the pending call with `nil` immediately, before the camera or gallery flow even started — the real scan result arrived later, found the callback already consumed, and was silently dropped. `getPictures()` resolved to `null` despite a successful scan and crop.
- A new `isHandlingAlertAction` flag is set right before the Camera/Gallery actions open their own flow and checked (then cleared) by the delegate, so that dismissal is ignored while an actual gesture-driven dismissal (e.g. tapping outside the iPad popover) still finishes with `nil` as before.
- Also ignores `ios/**/.build/`, the Swift Package Manager build directory, which was untracked but not excluded by any `.gitignore`.

## Test plan
- [x] Reproduced on a physical iPhone (iOS 26.5.2) via `flutter run`: confirmed `presentationControllerDidDismiss` fired right after tapping Gallery/Camera, dropping the later real result.
- [x] Applied the fix, rebuilt and reran on the same device: scanned/imported and cropped pages now show up correctly in the example app's result list.
- [x] `flutter build ios --no-codesign --simulator` succeeds.