### PR TITLE
fix(android): raise minSdk to 24, the lowest level actually reachable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.0.1
+
+### Changed
+* **The Android `minSdk` is now 24, up from the 21 previously declared.** 21 was never a level a host application could reach: Flutter's Gradle plugin fails the build below API 23, and `play-services-mlkit-document-scanner` declares 23 in its own manifest. 24 is Flutter's own default `minSdkVersion`, so a project that has not overridden it needs no change. **Applications pinned to API 23 are the exception** — they built and ran before and will now fail the manifest merge, and must either raise their `minSdk` to 24 or stay on 3.0.0. The README documented the unreachable 21 and has been corrected everywhere it appeared.
+
 ## 3.0.0
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -11,14 +11,14 @@
 
 ---
 
-Cunning Document Scanner is a Flutter-based document scanner application that enables you to capture images of paper documents and convert them into digital files effortlessly. This application is designed to run on Android and iOS devices with minimum API levels of 21 and 13, respectively.
+Cunning Document Scanner is a Flutter-based document scanner application that enables you to capture images of paper documents and convert them into digital files effortlessly. This application is designed to run on Android and iOS devices with minimum API levels of 24 and 13, respectively.
 
 ## Key Features
 
 - Fast and easy document scanning.
 - Conversion of document images into digital files, including direct PDF export.
 - Support for both Android and iOS platforms.
-- Minimum requirements: API 21 on Android, iOS 13 on iOS.
+- Minimum requirements: API 24 on Android, iOS 13 on iOS.
 - Limit the number of scanned pages on both platforms.
 - Import images from the gallery on both platforms, with manual cropping.
 - No third-party runtime dependencies.
@@ -39,14 +39,14 @@ Follow the steps below to set up your Flutter project on Android and iOS.
 
 #### Minimum Version Configuration
 Ensure you meet the minimum version requirements to run the application on Android devices.
-In `android/app/build.gradle`, verify that `minSdkVersion` (or `minSdk`) is at least **21**:
+In `android/app/build.gradle`, verify that `minSdkVersion` (or `minSdk`) is at least **24**:
 
 ```gradle
 android {
     ...
     defaultConfig {
         ...
-        minSdkVersion 21
+        minSdkVersion 24
         ...
     }
 }

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -2,7 +2,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import com.android.build.api.dsl.LibraryExtension
 
 group = "biz.cunning.cunning_document_scanner"
-version = "3.0.0"
+version = "3.0.1"
 
 plugins {
     id("com.android.library")
@@ -24,7 +24,7 @@ configure<LibraryExtension> {
     resourcePrefix = "cunning_"
 
     defaultConfig {
-        minSdk = 21
+        minSdk = 24
     }
 
     compileOptions {

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -71,7 +71,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "3.0.0"
+    version: "3.0.1"
   cupertino_icons:
     dependency: "direct main"
     description:

--- a/ios/cunning_document_scanner.podspec
+++ b/ios/cunning_document_scanner.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'cunning_document_scanner'
-  s.version          = '3.0.0'
+  s.version          = '3.0.1'
   s.summary          = 'A document scanner plugin for flutter.'
   s.description      = <<-DESC
 A document scanner plugin for flutter. Scan and crop automatically on iOS and Android.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cunning_document_scanner
 description: A document scanner plugin for flutter. Scan and crop automatically on iOS and Android.
-version: 3.0.0
+version: 3.0.1
 homepage: https://victorcarreras.dev/
 repository: https://github.com/vicajilau/cunning_document_scanner
 issue_tracker: https://github.com/vicajilau/cunning_document_scanner/issues


### PR DESCRIPTION
## Why

The plugin declared `minSdk = 21` and the README repeated it in four places, but **21 was never a level a host application could reach**:

| Layer | Real floor | Evidence |
|---|---|---|
| Plugin (declared) | 21 | `android/build.gradle.kts` |
| `play-services-mlkit-document-scanner:16.0.0` | **23** | `minSdkVersion="23"` in the AAR's `AndroidManifest.xml` |
| Flutter | **24** | `FlutterExtension.kt` (`minSdkVersion = 24`); `DependencyVersionChecker.kt` errors below 23, warns below 24 |

The `21` never surfaced because the example app uses `minSdk = flutter.minSdkVersion`, and AGP does not enforce a library module's `minSdk` against its own dependencies the way it does for an application module.

## What changed

- `android/build.gradle.kts`: `minSdk` 21 → 24.
- `README.md`: corrected in all four places that stated 21, with a note that 24 is Flutter's default.
- Version bumped to **3.0.1** in `pubspec.yaml`, the podspec and `android/build.gradle.kts`, with a changelog entry.

## Impact

Projects that leave `minSdk = flutter.minSdkVersion` untouched need no change — that is already 24.

**Applications pinned to API 23 do break.** That case built and ran before, since ML Kit's 23 was satisfied and Flutter only warned. I verified it by setting the example app to `minSdk = 23`:

```
Manifest merger failed : uses-sdk:minSdkVersion 23 cannot be smaller than
version 24 declared in library [:cunning_document_scanner]
```

They must raise their `minSdk` to 24 or stay on 3.0.0. Under strict semver this argues for a major bump; released as a patch deliberately, since API 23 is Android 6.0 (2015) and Flutter is dropping it regardless — its own check already prints "Flutter support for your project's minimum Android SDK version (23) will soon be dropped".

## Verification

- `tool/check_versions.sh` — all versions agree on 3.0.1.
- `flutter analyze` — no issues.
- `flutter build apk --debug` on the example — succeeds.
- Example forced to `minSdk = 23` — fails with the merge error above, then restored.