### PR TITLE
fix(android): make cleanCache() cover files the GMS scanner produces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 ## 3.0.1
-
 ### Changed
 * **The Android `minSdk` is now 24, up from the 21 previously declared.** 21 was never a level a host application could reach: Flutter's Gradle plugin fails the build below API 23, and `play-services-mlkit-document-scanner` declares 23 in its own manifest. 24 is Flutter's own default `minSdkVersion`, so a project that has not overridden it needs no change. **Applications pinned to API 23 are the exception** — they built and ran before and will now fail the manifest merge, and must either raise their `minSdk` to 24 or stay on 3.0.0. The README documented the unreachable 21 and has been corrected everywhere it appeared.
+
+### Fixed
+* **`cleanCache()` removed nothing on most Android devices.** The GMS/ML Kit document scanner is the primary Android path, and it writes its page images and PDFs under its own naming scheme rather than this plugin's `DOCUMENT_SCAN_` prefix, so `cleanCache()` never matched or removed them even though the plugin had returned those exact paths to Flutter as its own output. Each file is now copied into the plugin's own prefixed storage before its path is returned.
 
 ## 3.0.0
 

--- a/android/src/main/kotlin/biz/cunning/cunning_document_scanner/CunningDocumentScannerPlugin.kt
+++ b/android/src/main/kotlin/biz/cunning/cunning_document_scanner/CunningDocumentScannerPlugin.kt
@@ -25,6 +25,7 @@ import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
 import io.flutter.plugin.common.PluginRegistry
 import java.io.File
+import java.io.IOException
 
 // / Main Android plugin class for cunning_document_scanner.
 // / Handles Flutter MethodChannel calls, Google Play Services (GMS) document scanner triggers,
@@ -263,6 +264,10 @@ class CunningDocumentScannerPlugin :
     }
 
     // / Handles the result of the GMS ML Kit document scanner.
+    // /
+    // / ML Kit writes its output under its own naming scheme, not the `DOCUMENT_SCAN_` prefix
+    // / `cleanCache` looks for, so those files would never be found and removed. Each file is
+    // / copied into this plugin's own storage before its path is returned to Flutter.
     private fun handleGmsScannerResult(
         resultCode: Int,
         data: Intent?,
@@ -292,23 +297,30 @@ class CunningDocumentScannerPlugin :
             return
         }
 
-        if (asPdf) {
-            val pdfUri =
-                scanningResult.pdf
-                    ?.uri
-                    ?.toString()
-                    ?.removePrefix("file://")
-            if (pdfUri != null) {
-                resolve(listOf(pdfUri))
+        val context = applicationContext
+        if (context == null) {
+            fail("NO_CONTEXT", "Plugin is not attached to the Flutter engine")
+            return
+        }
+
+        try {
+            if (asPdf) {
+                val pdfUri = scanningResult.pdf?.uri
+                if (pdfUri != null) {
+                    val pdfFile = FileUtil().copyPdfToScanStorage(context, pdfUri)
+                    resolve(listOf(pdfFile.absolutePath))
+                } else {
+                    fail("ERROR", "No PDF returned from ML Kit scanner")
+                }
             } else {
-                fail("ERROR", "No PDF returned from ML Kit scanner")
+                val successResponse =
+                    scanningResult.pages.orEmpty().mapIndexed { index, page ->
+                        FileUtil().copyPageToScanStorage(context, page.imageUri, index).absolutePath
+                    }
+                resolve(successResponse)
             }
-        } else {
-            val successResponse =
-                scanningResult.pages
-                    ?.map { it.imageUri.toString().removePrefix("file://") }
-                    .orEmpty()
-            resolve(successResponse)
+        } catch (e: IOException) {
+            fail("ERROR", "Failed to persist ML Kit scanner output: ${e.message}")
         }
     }
 

--- a/android/src/main/kotlin/biz/cunning/cunning_document_scanner/fallback/utils/FileUtil.kt
+++ b/android/src/main/kotlin/biz/cunning/cunning_document_scanner/fallback/utils/FileUtil.kt
@@ -1,8 +1,10 @@
 package biz.cunning.cunning_document_scanner.fallback.utils
 
 import android.app.Activity
+import android.content.Context
 import android.graphics.BitmapFactory
 import android.graphics.pdf.PdfDocument
+import android.net.Uri
 import android.os.Environment
 import java.io.File
 import java.io.FileOutputStream
@@ -51,6 +53,76 @@ class FileUtil {
             ".pdf",
             storageDir,
         )
+    }
+
+    // / Copies a scanned page image the GMS ML Kit scanner produced into this plugin's own
+    // / `DOCUMENT_SCAN_`-prefixed storage, so `cleanCache` can find and remove it.
+    // / ML Kit owns and names the source file itself, outside this plugin's naming convention.
+    // / - context: Used to read the source URI and resolve the destination directory.
+    // / - sourceUri: The page image URI reported by the scanner result.
+    // / - pageNumber: The document page number used to prefix the filename.
+    @Throws(IOException::class)
+    fun copyPageToScanStorage(
+        context: Context,
+        sourceUri: Uri,
+        pageNumber: Int,
+    ): File {
+        val dateTime: String =
+            SimpleDateFormat(
+                "yyyyMMdd_HHmmss",
+                Locale.US,
+            ).format(Date())
+
+        val storageDir: File? = context.getExternalFilesDir(Environment.DIRECTORY_PICTURES)
+        val destFile =
+            File.createTempFile(
+                "DOCUMENT_SCAN_${pageNumber}_$dateTime",
+                ".jpg",
+                storageDir,
+            )
+        copyUriToFile(context, sourceUri, destFile)
+        return destFile
+    }
+
+    // / Copies a scanned PDF the GMS ML Kit scanner produced into this plugin's own
+    // / `DOCUMENT_SCAN_`-prefixed storage, so `cleanCache` can find and remove it.
+    // / - context: Used to read the source URI and resolve the destination directory.
+    // / - sourceUri: The PDF URI reported by the scanner result.
+    @Throws(IOException::class)
+    fun copyPdfToScanStorage(
+        context: Context,
+        sourceUri: Uri,
+    ): File {
+        val dateTime: String =
+            SimpleDateFormat(
+                "yyyyMMdd_HHmmss",
+                Locale.US,
+            ).format(Date())
+
+        val storageDir: File? = context.getExternalFilesDir(Environment.DIRECTORY_PICTURES)
+        val destFile =
+            File.createTempFile(
+                "DOCUMENT_SCAN_$dateTime",
+                ".pdf",
+                storageDir,
+            )
+        copyUriToFile(context, sourceUri, destFile)
+        return destFile
+    }
+
+    // / Streams the content behind a `content://` or `file://` URI into a destination file.
+    @Throws(IOException::class)
+    private fun copyUriToFile(
+        context: Context,
+        sourceUri: Uri,
+        destFile: File,
+    ) {
+        val input =
+            context.contentResolver.openInputStream(sourceUri)
+                ?: throw IOException("Unable to open scanner output at $sourceUri")
+        input.use { stream ->
+            FileOutputStream(destFile).use { output -> stream.copyTo(output) }
+        }
     }
 
     // / Compiles a list of image paths into a single output PDF document.


### PR DESCRIPTION
## Summary
- The GMS/ML Kit document scanner is the primary Android path (the fallback cropper only runs when Google Play Services is unavailable or fails), and it returns page images and PDFs it wrote itself under its own naming scheme.
- `cleanCache()` only ever matched files against the `DOCUMENT_SCAN_` prefix this plugin writes for the fallback path, so on a typical device (with GMS) it silently deleted nothing, even though the plugin was handing those exact file paths back to Flutter as its own output.
- Each GMS-produced page/PDF is now copied into this plugin's own `DOCUMENT_SCAN_`-prefixed file under the same pictures directory the fallback path already uses — the same directory and naming convention `cleanCache()` already scans — before its path is returned to Flutter.
- As a side effect, this also stops assuming the scanner result is always a `file://` URI whose scheme can just be string-stripped; the copy now goes through `ContentResolver`, which works for `content://` URIs too.
- Rebased on top of #164 (Android `minSdk` 24). 3.0.1 hasn't been published yet, so this is documented under that same still-unreleased CHANGELOG entry rather than a new version. (The iOS action-sheet fix in #163 merged while the version was still 3.0.0, also unpublished, so it never shipped as a bug in any released version and gets no changelog entry of its own.)

## Test plan
- [x] `./gradlew :cunning_document_scanner:compileDebugKotlin` succeeds.
- [x] `./gradlew :cunning_document_scanner:testDebugUnitTest` passes (existing `ScannerArgumentsTest` suite, unaffected by this change).
- [ ] Not yet verified end-to-end on a device with Google Play Services / the ML Kit document scanner module (unlike the iOS fix in #163, which was reproduced live on hardware). Worth a manual pass on a real GMS-enabled Android device before release.