### PR TITLE
fix(android): move the ML Kit scan out of its own storage instead of copying it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.0.2
+
+### Fixed
+* **The ML Kit scanner's own copy of every Android scan was left on disk.** The plugin copied each page image and PDF into its own `DOCUMENT_SCAN_`-prefixed storage and returned that path, but never removed the file ML Kit had written. That original is unreachable: its URI never crosses into Dart, and `cleanCache()` matches only the plugin's own prefix, so no application could delete it and two copies of every scanned document sat in the cache until the system chose to reclaim it. Reported in [#166](https://github.com/vicajilau/cunning_document_scanner/issues/166). The scanner output is now moved rather than copied: a local file is renamed, which also removes the window in which both copies exist, and anything that cannot be renamed is streamed out and its source deleted. Deletion is best-effort, so a source the plugin is not allowed to remove no longer fails an otherwise successful scan.
+
 ## 3.0.1
 ### Changed
 * **The Android `minSdk` is now 24, up from the 21 previously declared.** 21 was never a level a host application could reach: Flutter's Gradle plugin fails the build below API 23, and `play-services-mlkit-document-scanner` declares 23 in its own manifest. 24 is Flutter's own default `minSdkVersion`, so a project that has not overridden it needs no change. **Applications pinned to API 23 are the exception** — they built and ran before and will now fail the manifest merge, and must either raise their `minSdk` to 24 or stay on 3.0.0. The README documented the unreachable 21 and has been corrected everywhere it appeared.

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -2,7 +2,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import com.android.build.api.dsl.LibraryExtension
 
 group = "biz.cunning.cunning_document_scanner"
-version = "3.0.1"
+version = "3.0.2"
 
 plugins {
     id("com.android.library")

--- a/android/src/main/kotlin/biz/cunning/cunning_document_scanner/CunningDocumentScannerPlugin.kt
+++ b/android/src/main/kotlin/biz/cunning/cunning_document_scanner/CunningDocumentScannerPlugin.kt
@@ -267,7 +267,8 @@ class CunningDocumentScannerPlugin :
     // /
     // / ML Kit writes its output under its own naming scheme, not the `DOCUMENT_SCAN_` prefix
     // / `cleanCache` looks for, so those files would never be found and removed. Each file is
-    // / copied into this plugin's own storage before its path is returned to Flutter.
+    // / moved into this plugin's own storage before its path is returned to Flutter, which
+    // / leaves no second copy of the document behind for an application to worry about.
     private fun handleGmsScannerResult(
         resultCode: Int,
         data: Intent?,
@@ -307,7 +308,7 @@ class CunningDocumentScannerPlugin :
             if (asPdf) {
                 val pdfUri = scanningResult.pdf?.uri
                 if (pdfUri != null) {
-                    val pdfFile = FileUtil().copyPdfToScanStorage(context, pdfUri)
+                    val pdfFile = FileUtil().movePdfToScanStorage(context, pdfUri)
                     resolve(listOf(pdfFile.absolutePath))
                 } else {
                     fail("ERROR", "No PDF returned from ML Kit scanner")
@@ -315,7 +316,7 @@ class CunningDocumentScannerPlugin :
             } else {
                 val successResponse =
                     scanningResult.pages.orEmpty().mapIndexed { index, page ->
-                        FileUtil().copyPageToScanStorage(context, page.imageUri, index).absolutePath
+                        FileUtil().movePageToScanStorage(context, page.imageUri, index).absolutePath
                     }
                 resolve(successResponse)
             }

--- a/android/src/main/kotlin/biz/cunning/cunning_document_scanner/fallback/utils/FileUtil.kt
+++ b/android/src/main/kotlin/biz/cunning/cunning_document_scanner/fallback/utils/FileUtil.kt
@@ -1,6 +1,7 @@
 package biz.cunning.cunning_document_scanner.fallback.utils
 
 import android.app.Activity
+import android.content.ContentResolver
 import android.content.Context
 import android.graphics.BitmapFactory
 import android.graphics.pdf.PdfDocument
@@ -55,14 +56,14 @@ class FileUtil {
         )
     }
 
-    // / Copies a scanned page image the GMS ML Kit scanner produced into this plugin's own
+    // / Moves a scanned page image the GMS ML Kit scanner produced into this plugin's own
     // / `DOCUMENT_SCAN_`-prefixed storage, so `cleanCache` can find and remove it.
     // / ML Kit owns and names the source file itself, outside this plugin's naming convention.
     // / - context: Used to read the source URI and resolve the destination directory.
     // / - sourceUri: The page image URI reported by the scanner result.
     // / - pageNumber: The document page number used to prefix the filename.
     @Throws(IOException::class)
-    fun copyPageToScanStorage(
+    fun movePageToScanStorage(
         context: Context,
         sourceUri: Uri,
         pageNumber: Int,
@@ -80,16 +81,16 @@ class FileUtil {
                 ".jpg",
                 storageDir,
             )
-        copyUriToFile(context, sourceUri, destFile)
+        moveUriToFile(context, sourceUri, destFile)
         return destFile
     }
 
-    // / Copies a scanned PDF the GMS ML Kit scanner produced into this plugin's own
+    // / Moves a scanned PDF the GMS ML Kit scanner produced into this plugin's own
     // / `DOCUMENT_SCAN_`-prefixed storage, so `cleanCache` can find and remove it.
     // / - context: Used to read the source URI and resolve the destination directory.
     // / - sourceUri: The PDF URI reported by the scanner result.
     @Throws(IOException::class)
-    fun copyPdfToScanStorage(
+    fun movePdfToScanStorage(
         context: Context,
         sourceUri: Uri,
     ): File {
@@ -106,8 +107,72 @@ class FileUtil {
                 ".pdf",
                 storageDir,
             )
-        copyUriToFile(context, sourceUri, destFile)
+        moveUriToFile(context, sourceUri, destFile)
         return destFile
+    }
+
+    // / Moves the content behind a `content://` or `file://` URI into a destination file,
+    // / leaving nothing behind at the source.
+    // /
+    // / Copying alone would strand the scanner's own file: its URI never crosses into Dart,
+    // / and `cleanCache` matches only this plugin's `DOCUMENT_SCAN_` prefix, so no caller
+    // / could ever reach it. Two copies of a scanned document would sit on disk until the
+    // / system reclaimed the cache, which for a confidential scan is exactly the wrong
+    // / default.
+    // /
+    // / A `file://` source is renamed when possible. That avoids writing the document a
+    // / second time and leaves no window in which both copies exist. A rename across
+    // / storage volumes fails, and a `content://` source cannot be renamed at all, so both
+    // / fall back to a stream-and-remove.
+    @Throws(IOException::class)
+    private fun moveUriToFile(
+        context: Context,
+        sourceUri: Uri,
+        destFile: File,
+    ) {
+        val sourceFile = asLocalFile(sourceUri)
+        if (sourceFile != null && sourceFile.renameTo(destFile)) {
+            return
+        }
+
+        copyUriToFile(context, sourceUri, destFile)
+        deleteSource(context, sourceUri, sourceFile)
+    }
+
+    // / Resolves a URI to the file it points at, or null when it does not name one directly.
+    // / A missing scheme is treated as a bare filesystem path, which is how `Uri.parse`
+    // / represents one.
+    private fun asLocalFile(sourceUri: Uri): File? {
+        val scheme = sourceUri.scheme
+        if (scheme != null && scheme != ContentResolver.SCHEME_FILE) {
+            return null
+        }
+        return sourceUri.path?.let { File(it) }
+    }
+
+    // / Removes the scanner's original after its content has been copied out.
+    // /
+    // / Best-effort by design: the scan itself was read correctly and is already safe in
+    // / this plugin's storage, so a source that refuses to be deleted must not turn a
+    // / successful scan into a failure. A `content://` provider owned by another process
+    // / may reject the delete outright, and the read grant this plugin holds does not
+    // / imply a write one.
+    private fun deleteSource(
+        context: Context,
+        sourceUri: Uri,
+        sourceFile: File?,
+    ) {
+        try {
+            if (sourceFile != null) {
+                sourceFile.delete()
+            } else {
+                context.contentResolver.delete(sourceUri, null, null)
+            }
+        } catch (_: RuntimeException) {
+            // SecurityException, UnsupportedOperationException and IllegalArgumentException
+            // all mean the same thing here: this process is not allowed to remove the
+            // source, and there is nothing further to try.
+        }
     }
 
     // / Streams the content behind a `content://` or `file://` URI into a destination file.

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -71,7 +71,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "3.0.1"
+    version: "3.0.2"
   cupertino_icons:
     dependency: "direct main"
     description:

--- a/ios/cunning_document_scanner.podspec
+++ b/ios/cunning_document_scanner.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'cunning_document_scanner'
-  s.version          = '3.0.1'
+  s.version          = '3.0.2'
   s.summary          = 'A document scanner plugin for flutter.'
   s.description      = <<-DESC
 A document scanner plugin for flutter. Scan and crop automatically on iOS and Android.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cunning_document_scanner
 description: A document scanner plugin for flutter. Scan and crop automatically on iOS and Android.
-version: 3.0.1
+version: 3.0.2
 homepage: https://victorcarreras.dev/
 repository: https://github.com/vicajilau/cunning_document_scanner
 issue_tracker: https://github.com/vicajilau/cunning_document_scanner/issues


### PR DESCRIPTION
Closes #166.

## The problem

The reporter is right, and the code confirms it. Since #165 the plugin copies every GMS/ML Kit result into its own `DOCUMENT_SCAN_`-prefixed storage and returns that path, but the file ML Kit wrote is never removed.

Nothing can remove it either:

* The source URI never crosses into Dart, so an application has no handle on it.
* `cleanCache()` walks only the top level of `cacheDir` and the pictures directory, matching the `DOCUMENT_SCAN_` prefix. ML Kit writes into a subdirectory of its own, under its own naming scheme, so the scan is missed twice over.

The result is two copies of every scanned document sitting on disk until the system decides to reclaim the cache, which may take a long time or never happen. For the confidential-document case in the issue that is the wrong default.

## The fix

The scanner output is moved rather than copied.

* A `file://` source is renamed into the destination. That avoids writing the document a second time and, more to the point of the issue, leaves no window in which both copies exist on disk.
* A `content://` source, or a rename that fails because the two paths sit on different volumes, falls back to the previous stream-out followed by a delete of the source.
* Deletion is best-effort. By that point the scan has been read correctly and is already safe in the plugin's storage, so a source this process is not allowed to remove must not turn a successful scan into a failure. A provider owned by another process can reject the delete, and the read grant the plugin holds does not imply a write one.

I did not add an option for this, which the issue offered as an alternative. The copy is already unconditional and the original is unreachable by callers, so there is no case in which keeping it does anything for an application. An option would only add a combination to document and test.

## Notes

* `movePageToScanStorage` and `movePdfToScanStorage` replace the `copy*` names, since the semantics changed. They are internal to the plugin and are not part of the Dart API.
* The PDF path does not need to clean up page images: `setResultFormats` is called with either `RESULT_FORMAT_PDF` or `RESULT_FORMAT_JPEG`, never both, so a PDF result carries no pages.
* No unit test covers this. `android.net.Uri` is not implemented in plain JVM unit tests and the project has no Robolectric setup, so testing it would mean bringing in instrumentation. Verified by building the example APK, and `ktlint` and `:cunning_document_scanner:testDebugUnitTest` both pass.

## Version

Bumped to 3.0.2, since 3.0.1 is already tagged and published.