### PR TITLE
chore(example): bump the example app's Kotlin plugin to 2.4.10

### DIFF
--- a/example/android/settings.gradle.kts
+++ b/example/android/settings.gradle.kts
@@ -18,7 +18,7 @@ pluginManagement {
 plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
     id("com.android.application") version "9.2.1" apply false
-    id("org.jetbrains.kotlin.android") version "2.2.21" apply false
+    id("org.jetbrains.kotlin.android") version "2.4.10" apply false
     id("org.gradle.toolchains.foojay-resolver-convention") version "0.10.0"
 }
 


### PR DESCRIPTION
Every `flutter run` and `flutter build` on the example app prints:

```
Warning: Flutter support for your project's Kotlin version (2.2.21) will soon be dropped.
Please upgrade your Kotlin version to a version of at least 2.3.20 soon.
```

`example/android/settings.gradle.kts` pinned `org.jetbrains.kotlin.android` at 2.2.21. This moves it to 2.4.10, the current stable release on Maven Central, rather than to 2.3.20 exactly, since that is the version Flutter already treats as the floor.

Only the example application is affected. The plugin declares no Kotlin version of its own: `android/build.gradle.kts` applies `org.jetbrains.kotlin.android` only when AGP is older than 9, and otherwise relies on AGP's built-in Kotlin support, so a consuming application keeps resolving whatever version it already uses.

Verified with `flutter build apk --debug` (warning gone) and `:cunning_document_scanner:testDebugUnitTest`.

No version bump or changelog entry, since nothing in the published package changes.